### PR TITLE
Added Dark mode toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
-        "react-icons": "^5.0.1",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^6.21.3",
         "socket.io-client": "^4.7.4",
         "zustand": "^4.5.0"
@@ -4093,9 +4093,10 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
-    "react-icons": "^5.0.1",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^6.21.3",
     "socket.io-client": "^4.7.4",
     "zustand": "^4.5.0"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useContext } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+// frontend/src/App.jsx
+
+import { Navigate, Route, Routes, Outlet } from "react-router-dom";
 import "./App.css";
 import Home from "./pages/home/Home";
 import Login from "./pages/login/Login";
@@ -7,22 +8,25 @@ import SignUp from "./pages/signup/SignUp";
 import ForgotPassword from "./pages/ForgotPassword/ForgotPassword";
 import { Toaster } from "react-hot-toast";
 import { useAuthContext } from "./context/AuthContext";
+import { useContext } from "react";
 import { ThemeContext } from "./context/ThemeContext";
-import MagicCursorTrail from "./components/MagicCursorTrail";
+import AuthLayout from "./components/layout/AuthLayout";
 
 function App() {
     const { authUser } = useAuthContext();
     const { theme } = useContext(ThemeContext);
-    const enableCursorTrail = true;
 
     return (
         <div className='p-4 h-screen flex items-center justify-center'>
-            {enableCursorTrail && <MagicCursorTrail />}
             <Routes>
                 <Route path='/' element={authUser ? <Home /> : <Navigate to={"/login"} />} />
-                <Route path='/login' element={authUser ? <Navigate to='/' /> : <Login />} />
-                <Route path="/forgot-password" element={<ForgotPassword />} />
-                <Route path='/signup' element={authUser ? <Navigate to='/' /> : <SignUp />} />
+
+                {/* All auth routes will now use the AuthLayout */}
+                <Route element={authUser ? <Navigate to='/' /> : <AuthLayout />}>
+                    <Route path='/login' element={<Login />} />
+                    <Route path='/signup' element={<SignUp />} />
+                    <Route path="/forgot-password" element={<ForgotPassword />} />
+                </Route>
             </Routes>
             <Toaster
                 toastOptions={{

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useContext } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import "./App.css";
 import Home from "./pages/home/Home";
@@ -7,26 +7,33 @@ import SignUp from "./pages/signup/SignUp";
 import ForgotPassword from "./pages/ForgotPassword/ForgotPassword";
 import { Toaster } from "react-hot-toast";
 import { useAuthContext } from "./context/AuthContext";
-import MagicCursorTrail from "./components/MagicCursorTrail"; // Adjust path as needed
-
+import { ThemeContext } from "./context/ThemeContext";
+import MagicCursorTrail from "./components/MagicCursorTrail";
 
 function App() {
-	const { authUser } = useAuthContext();
-	const enableCursorTrail = true;
-	return (
-		<div className='p-4 h-screen flex items-center justify-center'>
-			{enableCursorTrail && <MagicCursorTrail />}
-			<Routes>
-				<Route path='/' element={authUser ? <Home /> : <Navigate to={"/login"} />} />
-				<Route path='/login' element={authUser ? <Navigate to='/' /> : <Login />} />
-				<Route path="/forgot-password" element={<ForgotPassword />} />
-				<Route path='/signup' element={authUser ? <Navigate to='/' /> : <SignUp />} />
-			</Routes>
-			<Toaster />
-		</div>
-	);
+    const { authUser } = useAuthContext();
+    const { theme } = useContext(ThemeContext);
+    const enableCursorTrail = true;
+
+    return (
+        <div className='p-4 h-screen flex items-center justify-center'>
+            {enableCursorTrail && <MagicCursorTrail />}
+            <Routes>
+                <Route path='/' element={authUser ? <Home /> : <Navigate to={"/login"} />} />
+                <Route path='/login' element={authUser ? <Navigate to='/' /> : <Login />} />
+                <Route path="/forgot-password" element={<ForgotPassword />} />
+                <Route path='/signup' element={authUser ? <Navigate to='/' /> : <SignUp />} />
+            </Routes>
+            <Toaster
+                toastOptions={{
+                    style: {
+                        background: theme === 'dark' ? '#374151' : '#ffffff',
+                        color: theme === 'dark' ? '#ffffff' : '#000000',
+                    },
+                }}
+            />
+        </div>
+    );
 }
-
-
 
 export default App;

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,19 @@
+
+import React, { useContext } from 'react';
+import { ThemeContext } from '../context/ThemeContext';
+import { BsFillSunFill, BsFillMoonFill } from 'react-icons/bs';
+
+const ThemeToggle = () => {
+  const { theme, setTheme } = useContext(ThemeContext);
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className="p-2 rounded-full text-lg"
+    >
+      {theme === 'dark' ? <BsFillSunFill /> : <BsFillMoonFill />}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/components/layout/AuthLayout.jsx
+++ b/frontend/src/components/layout/AuthLayout.jsx
@@ -1,0 +1,18 @@
+import { Outlet } from "react-router-dom";
+import ThemeToggle from "../ThemeToggle";
+
+const AuthLayout = () => {
+    return (
+        <div className="flex flex-col items-center justify-center min-w-96 mx-auto">
+            <div className="w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0 dark:bg-black/30 relative">
+                <div className="absolute top-4 right-4">
+                    <ThemeToggle />
+                </div>
+                {/* This Outlet component will render the specific page (Login, SignUp, etc.) */}
+                <Outlet />
+            </div>
+        </div>
+    );
+};
+
+export default AuthLayout;

--- a/frontend/src/components/messages/Message.jsx
+++ b/frontend/src/components/messages/Message.jsx
@@ -3,26 +3,27 @@ import { extractTime } from "../../utils/extractTime";
 import useConversation from "../../zustand/useConversation";
 
 const Message = ({ message }) => {
-	const { authUser } = useAuthContext();
-	const { selectedConversation } = useConversation();
-	const fromMe = message.senderId === authUser._id;
-	const formattedTime = extractTime(message.createdAt);
-	const chatClassName = fromMe ? "chat-end" : "chat-start";
-	const profilePic = fromMe ? authUser.profilePic : selectedConversation?.profilePic;
-	const bubbleBgColor = fromMe ? "bg-blue-500" : "";
+    const { authUser } = useAuthContext();
+    const { selectedConversation } = useConversation();
+    const fromMe = message.senderId === authUser._id;
+    const formattedTime = extractTime(message.createdAt);
+    const chatClassName = fromMe ? "chat-end" : "chat-start";
+    const profilePic = fromMe ? authUser.profilePic : selectedConversation?.profilePic;
+    const bubbleBgColor = fromMe ? "bg-blue-500 dark:bg-blue-700" : "bg-gray-200 dark:bg-gray-600";
+    const bubbleTextColor = fromMe ? "text-white" : "text-gray-800 dark:text-white";
 
-	const shakeClass = message.shouldShake ? "shake" : "";
+    const shakeClass = message.shouldShake ? "shake" : "";
 
-	return (
-		<div className={`chat ${chatClassName}`}>
-			<div className='chat-image avatar'>
-				<div className='w-10 rounded-full'>
-					<img alt='Tailwind CSS chat bubble component' src={profilePic} />
-				</div>
-			</div>
-			<div className={`chat-bubble text-white ${bubbleBgColor} ${shakeClass} pb-2`}>{message.message}</div>
-			<div className='chat-footer opacity-50 text-xs flex gap-1 items-center'>{formattedTime}</div>
-		</div>
-	);
+    return (
+        <div className={`chat ${chatClassName}`}>
+            <div className='chat-image avatar'>
+                <div className='w-10 rounded-full'>
+                    <img alt='Tailwind CSS chat bubble component' src={profilePic} />
+                </div>
+            </div>
+            <div className={`chat-bubble ${bubbleTextColor} ${bubbleBgColor} ${shakeClass} pb-2`}>{message.message}</div>
+            <div className='chat-footer opacity-50 text-xs flex gap-1 items-center text-gray-800 dark:text-gray-300'>{formattedTime}</div>
+        </div>
+    );
 };
 export default Message;

--- a/frontend/src/components/messages/MessageContainer.jsx
+++ b/frontend/src/components/messages/MessageContainer.jsx
@@ -6,44 +6,44 @@ import { TiMessages } from "react-icons/ti";
 import { useAuthContext } from "../../context/AuthContext";
 
 const MessageContainer = () => {
-	const { selectedConversation, setSelectedConversation } = useConversation();
+    const { selectedConversation, setSelectedConversation } = useConversation();
 
-	useEffect(() => {
-		// cleanup function (unmounts)
-		return () => setSelectedConversation(null);
-	}, [setSelectedConversation]);
+    useEffect(() => {
+        // cleanup function (unmounts)
+        return () => setSelectedConversation(null);
+    }, [setSelectedConversation]);
 
-	return (
-		<div className='md:min-w-[450px] flex flex-col'>
-			{!selectedConversation ? (
-				<NoChatSelected />
-			) : (
-				<>
-					{/* Header */}
-					<div className='bg-slate-500 px-4 py-2 mb-2'>
-						<span className='label-text'>To:</span>{" "}
-						<span className='text-gray-900 font-bold'>{selectedConversation.fullName}</span>
-					</div>
-					<Messages />
-					<MessageInput />
-				</>
-			)}
-		</div>
-	);
+    return (
+        <div className='md:min-w-[450px] flex flex-col bg-gray-100 dark:bg-gray-800'>
+            {!selectedConversation ? (
+                <NoChatSelected />
+            ) : (
+                <>
+                    {/* Header */}
+                    <div className='bg-slate-300 dark:bg-slate-700 px-4 py-2 mb-2'>
+                        <span className='label-text text-gray-800 dark:text-gray-200'>To:</span>{" "}
+                        <span className='text-gray-900 dark:text-white font-bold'>{selectedConversation.fullName}</span>
+                    </div>
+                    <Messages />
+                    <MessageInput />
+                </>
+            )}
+        </div>
+    );
 };
 export default MessageContainer;
 
 const NoChatSelected = () => {
-	const { authUser } = useAuthContext();
-	return (
-		<div className='flex items-center justify-center w-full h-full'>
-			<div className='px-4 text-center sm:text-lg md:text-xl text-gray-200 font-semibold flex flex-col items-center gap-2'>
-				<p>Welcome 👋 {authUser.fullName} ❄</p>
-				<p>Select a chat to start messaging</p>
-				<TiMessages className='text-3xl md:text-6xl text-center' />
-			</div>
-		</div>
-	);
+    const { authUser } = useAuthContext();
+    return (
+        <div className='flex items-center justify-center w-full h-full'>
+            <div className='px-4 text-center sm:text-lg md:text-xl text-gray-800 dark:text-gray-200 font-semibold flex flex-col items-center gap-2'>
+                <p>Welcome 👋 {authUser.fullName} ❄</p>
+                <p>Select a chat to start messaging</p>
+                <TiMessages className='text-3xl md:text-6xl text-center' />
+            </div>
+        </div>
+    );
 };
 
 // STARTER CODE SNIPPET
@@ -51,18 +51,18 @@ const NoChatSelected = () => {
 // import Messages from "./Messages";
 
 // const MessageContainer = () => {
-// 	return (
-// 		<div className='md:min-w-[450px] flex flex-col'>
-// 			<>
-// 				{/* Header */}
-// 				<div className='bg-slate-500 px-4 py-2 mb-2'>
-// 					<span className='label-text'>To:</span> <span className='text-gray-900 font-bold'>John doe</span>
-// 				</div>
+//  return (
+//      <div className='md:min-w-[450px] flex flex-col'>
+//          <>
+//              {/* Header */}
+//              <div className='bg-slate-500 px-4 py-2 mb-2'>
+//                  <span className='label-text'>To:</span> <span className='text-gray-900 font-bold'>John doe</span>
+//              </div>
 
-// 				<Messages />
-// 				<MessageInput />
-// 			</>
-// 		</div>
-// 	);
+//              <Messages />
+//              <MessageInput />
+//          </>
+//      </div>
+//  );
 // };
 // export default MessageContainer;

--- a/frontend/src/components/messages/MessageInput.jsx
+++ b/frontend/src/components/messages/MessageInput.jsx
@@ -3,32 +3,32 @@ import { BsSend } from "react-icons/bs";
 import useSendMessage from "../../hooks/useSendMessage";
 
 const MessageInput = () => {
-	const [message, setMessage] = useState("");
-	const { loading, sendMessage } = useSendMessage();
+    const [message, setMessage] = useState("");
+    const { loading, sendMessage } = useSendMessage();
 
-	const handleSubmit = async (e) => {
-		e.preventDefault();
-		if (!message) return;
-		await sendMessage(message);
-		setMessage("");
-	};
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!message) return;
+        await sendMessage(message);
+        setMessage("");
+    };
 
-	return (
-		<form className='px-4 my-3' onSubmit={handleSubmit}>
-			<div className='w-full relative'>
-				<input
-					type='text'
-					className='border text-sm rounded-lg block w-full p-2.5  bg-gray-700 border-gray-600 text-white'
-					placeholder='Send a message'
-					value={message}
-					onChange={(e) => setMessage(e.target.value)}
-				/>
-				<button type='submit' className='absolute inset-y-0 end-0 flex items-center pe-3'>
-					{loading ? <div className='loading loading-spinner'></div> : <BsSend />}
-				</button>
-			</div>
-		</form>
-	);
+    return (
+        <form className='px-4 my-3' onSubmit={handleSubmit}>
+            <div className='w-full relative'>
+                <input
+                    type='text'
+                    className='border text-sm rounded-lg block w-full p-2.5 bg-white border-gray-300 text-gray-900 dark:bg-gray-700 dark:border-gray-600 dark:text-white'
+                    placeholder='Send a message'
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                />
+                <button type='submit' className='absolute inset-y-0 end-0 flex items-center pe-3 text-gray-800 dark:text-white'>
+                    {loading ? <div className='loading loading-spinner'></div> : <BsSend />}
+                </button>
+            </div>
+        </form>
+    );
 };
 export default MessageInput;
 
@@ -36,19 +36,19 @@ export default MessageInput;
 // import { BsSend } from "react-icons/bs";
 
 // const MessageInput = () => {
-// 	return (
-// 		<form className='px-4 my-3'>
-// 			<div className='w-full'>
-// 				<input
-// 					type='text'
-// 					className='border text-sm rounded-lg block w-full p-2.5  bg-gray-700 border-gray-600 text-white'
-// 					placeholder='Send a message'
-// 				/>
-// 				<button type='submit' className='absolute inset-y-0 end-0 flex items-center pe-3'>
-// 					<BsSend />
-// 				</button>
-// 			</div>
-// 		</form>
-// 	);
+//  return (
+//      <form className='px-4 my-3'>
+//          <div className='w-full'>
+//              <input
+//                  type='text'
+//                  className='border text-sm rounded-lg block w-full p-2.5  bg-gray-700 border-gray-600 text-white'
+//                  placeholder='Send a message'
+//              />
+//              <button type='submit' className='absolute inset-y-0 end-0 flex items-center pe-3'>
+//                  <BsSend />
+//              </button>
+//          </div>
+//      </form>
+//  );
 // };
 // export default MessageInput;

--- a/frontend/src/components/messages/Messages.jsx
+++ b/frontend/src/components/messages/Messages.jsx
@@ -5,32 +5,32 @@ import Message from "./Message";
 import useListenMessages from "../../hooks/useListenMessages";
 
 const Messages = () => {
-	const { messages, loading } = useGetMessages();
-	useListenMessages();
-	const lastMessageRef = useRef();
+    const { messages, loading } = useGetMessages();
+    useListenMessages();
+    const lastMessageRef = useRef();
 
-	useEffect(() => {
-		setTimeout(() => {
-			lastMessageRef.current?.scrollIntoView({ behavior: "smooth" });
-		}, 100);
-	}, [messages]);
+    useEffect(() => {
+        setTimeout(() => {
+            lastMessageRef.current?.scrollIntoView({ behavior: "smooth" });
+        }, 100);
+    }, [messages]);
 
-	return (
-		<div className='px-4 flex-1 overflow-auto'>
-			{!loading &&
-				messages.length > 0 &&
-				messages.map((message) => (
-					<div key={message._id} ref={lastMessageRef}>
-						<Message message={message} />
-					</div>
-				))}
+    return (
+        <div className='px-4 flex-1 overflow-auto'>
+            {!loading &&
+                messages.length > 0 &&
+                messages.map((message) => (
+                    <div key={message._id} ref={lastMessageRef}>
+                        <Message message={message} />
+                    </div>
+                ))}
 
-			{loading && [...Array(3)].map((_, idx) => <MessageSkeleton key={idx} />)}
-			{!loading && messages.length === 0 && (
-				<p className='text-center'>Send a message to start the conversation</p>
-			)}
-		</div>
-	);
+            {loading && [...Array(3)].map((_, idx) => <MessageSkeleton key={idx} />)}
+            {!loading && messages.length === 0 && (
+                <p className='text-center text-gray-800 dark:text-gray-200'>Send a message to start the conversation</p>
+            )}
+        </div>
+    );
 };
 export default Messages;
 
@@ -38,21 +38,21 @@ export default Messages;
 // import Message from "./Message";
 
 // const Messages = () => {
-// 	return (
-// 		<div className='px-4 flex-1 overflow-auto'>
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 			<Message />
-// 		</div>
-// 	);
+//  return (
+//      <div className='px-4 flex-1 overflow-auto'>
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//          <Message />
+//      </div>
+//  );
 // };
 // export default Messages;

--- a/frontend/src/components/sidebar/Conversation.jsx
+++ b/frontend/src/components/sidebar/Conversation.jsx
@@ -2,64 +2,64 @@ import { useSocketContext } from "../../context/SocketContext";
 import useConversation from "../../zustand/useConversation";
 
 const Conversation = ({ conversation, lastIdx, emoji }) => {
-	const { selectedConversation, setSelectedConversation } = useConversation();
+    const { selectedConversation, setSelectedConversation } = useConversation();
 
-	const isSelected = selectedConversation?._id === conversation._id;
-	const { onlineUsers } = useSocketContext();
-	const isOnline = onlineUsers.includes(conversation._id);
+    const isSelected = selectedConversation?._id === conversation._id;
+    const { onlineUsers } = useSocketContext();
+    const isOnline = onlineUsers.includes(conversation._id);
 
-	return (
-		<>
-			<div
-				className={`flex gap-2 items-center hover:bg-sky-500 rounded p-2 py-1 cursor-pointer
-				${isSelected ? "bg-sky-500" : ""}
-			`}
-				onClick={() => setSelectedConversation(conversation)}
-			>
-				<div className={`avatar ${isOnline ? "online" : ""}`}>
-					<div className='w-12 rounded-full'>
-						<img src={conversation.profilePic} alt='user avatar' />
-					</div>
-				</div>
+    return (
+        <>
+            <div
+                className={`flex gap-2 items-center hover:bg-sky-500 dark:hover:bg-sky-700 rounded p-2 py-1 cursor-pointer
+                ${isSelected ? "bg-sky-500 dark:bg-sky-700" : ""}
+            `}
+                onClick={() => setSelectedConversation(conversation)}
+            >
+                <div className={`avatar ${isOnline ? "online" : ""}`}>
+                    <div className='w-12 rounded-full'>
+                        <img src={conversation.profilePic} alt='user avatar' />
+                    </div>
+                </div>
 
-				<div className='flex flex-col flex-1'>
-					<div className='flex gap-3 justify-between'>
-						<p className='font-bold text-gray-200'>{conversation.fullName}</p>
-						<span className='text-xl'>{emoji}</span>
-					</div>
-				</div>
-			</div>
+                <div className='flex flex-col flex-1'>
+                    <div className='flex gap-3 justify-between'>
+                        <p className={`font-bold ${isSelected ? 'text-white' : 'text-gray-800 dark:text-gray-200'}`}>{conversation.fullName}</p>
+                        <span className='text-xl'>{emoji}</span>
+                    </div>
+                </div>
+            </div>
 
-			{!lastIdx && <div className='divider my-0 py-0 h-1' />}
-		</>
-	);
+            {!lastIdx && <div className='divider my-0 py-0 h-1' />}
+        </>
+    );
 };
 export default Conversation;
 
 // STARTER CODE SNIPPET
 // const Conversation = () => {
-// 	return (
-// 		<>
-// 			<div className='flex gap-2 items-center hover:bg-sky-500 rounded p-2 py-1 cursor-pointer'>
-// 				<div className='avatar online'>
-// 					<div className='w-12 rounded-full'>
-// 						<img
-// 							src='https://cdn0.iconfinder.com/data/icons/communication-line-10/24/account_profile_user_contact_person_avatar_placeholder-512.png'
-// 							alt='user avatar'
-// 						/>
-// 					</div>
-// 				</div>
+//  return (
+//      <>
+//          <div className='flex gap-2 items-center hover:bg-sky-500 rounded p-2 py-1 cursor-pointer'>
+//              <div className='avatar online'>
+//                  <div className='w-12 rounded-full'>
+//                      <img
+//                          src='https://cdn0.iconfinder.com/data/icons/communication-line-10/24/account_profile_user_contact_person_avatar_placeholder-512.png'
+//                          alt='user avatar'
+//                      />
+//                  </div>
+//              </div>
 
-// 				<div className='flex flex-col flex-1'>
-// 					<div className='flex gap-3 justify-between'>
-// 						<p className='font-bold text-gray-200'>John Doe</p>
-// 						<span className='text-xl'>🎃</span>
-// 					</div>
-// 				</div>
-// 			</div>
+//              <div className='flex flex-col flex-1'>
+//                  <div className='flex gap-3 justify-between'>
+//                      <p className='font-bold text-gray-200'>John Doe</p>
+//                      <span className='text-xl'>🎃</span>
+//                  </div>
+//              </div>
+//          </div>
 
-// 			<div className='divider my-0 py-0 h-1' />
-// 		</>
-// 	);
+//          <div className='divider my-0 py-0 h-1' />
+//      </>
+//  );
 // };
 // export default Conversation;

--- a/frontend/src/components/sidebar/Conversations.jsx
+++ b/frontend/src/components/sidebar/Conversations.jsx
@@ -3,21 +3,21 @@ import { getRandomEmoji } from "../../utils/emojis";
 import Conversation from "./Conversation";
 
 const Conversations = () => {
-	const { loading, conversations } = useGetConversations();
-	return (
-		<div className='py-2 flex flex-col overflow-auto'>
-			{conversations.map((conversation, idx) => (
-				<Conversation
-					key={conversation._id}
-					conversation={conversation}
-					emoji={getRandomEmoji()}
-					lastIdx={idx === conversations.length - 1}
-				/>
-			))}
+    const { loading, conversations } = useGetConversations();
+    return (
+        <div className='py-2 flex flex-col overflow-auto'>
+            {conversations.map((conversation, idx) => (
+                <Conversation
+                    key={conversation._id}
+                    conversation={conversation}
+                    emoji={getRandomEmoji()}
+                    lastIdx={idx === conversations.length - 1}
+                />
+            ))}
 
-			{loading ? <span className='loading loading-spinner mx-auto'></span> : null}
-		</div>
-	);
+            {loading ? <span className='loading loading-spinner mx-auto text-gray-800 dark:text-gray-200'></span> : null}
+        </div>
+    );
 };
 export default Conversations;
 
@@ -25,15 +25,15 @@ export default Conversations;
 // import Conversation from "./Conversation";
 
 // const Conversations = () => {
-// 	return (
-// 		<div className='py-2 flex flex-col overflow-auto'>
-// 			<Conversation />
-// 			<Conversation />
-// 			<Conversation />
-// 			<Conversation />
-// 			<Conversation />
-// 			<Conversation />
-// 		</div>
-// 	);
+//  return (
+//      <div className='py-2 flex flex-col overflow-auto'>
+//          <Conversation />
+//          <Conversation />
+//          <Conversation />
+//          <Conversation />
+//          <Conversation />
+//          <Conversation />
+//      </div>
+//  );
 // };
 // export default Conversations;

--- a/frontend/src/components/sidebar/LogoutButton.jsx
+++ b/frontend/src/components/sidebar/LogoutButton.jsx
@@ -2,16 +2,16 @@ import { BiLogOut } from "react-icons/bi";
 import useLogout from "../../hooks/useLogout";
 
 const LogoutButton = () => {
-	const { loading, logout } = useLogout();
+    const { loading, logout } = useLogout();
 
-	return (
-		<div className='mt-auto'>
-			{!loading ? (
-				<BiLogOut className='w-6 h-6 text-white cursor-pointer' onClick={logout} />
-			) : (
-				<span className='loading loading-spinner'></span>
-			)}
-		</div>
-	);
+    return (
+        <div className='mt-auto'>
+            {!loading ? (
+                <BiLogOut className='w-6 h-6 text-gray-800 dark:text-white cursor-pointer' onClick={logout} />
+            ) : (
+                <span className='loading loading-spinner'></span>
+            )}
+        </div>
+    );
 };
 export default LogoutButton;

--- a/frontend/src/components/sidebar/SearchInput.jsx
+++ b/frontend/src/components/sidebar/SearchInput.jsx
@@ -5,52 +5,41 @@ import useGetConversations from "../../hooks/useGetConversations";
 import toast from "react-hot-toast";
 
 const SearchInput = () => {
-	const [search, setSearch] = useState("");
-	const { setSelectedConversation } = useConversation();
-	const { conversations } = useGetConversations();
+    const [search, setSearch] = useState("");
+    const { setSelectedConversation } = useConversation();
+    const { conversations } = useGetConversations();
 
-	const handleSubmit = (e) => {
-		e.preventDefault();
-		if (!search) return;
-		if (search.length < 3) {
-			return toast.error("Search term must be at least 3 characters long");
-		}
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (!search) return;
+        if (search.length < 3) {
+            return toast.error("Search term must be at least 3 characters long");
+        }
 
-		const conversation = conversations.find((c) => c.fullName.toLowerCase().includes(search.toLowerCase()));
+        const conversation = conversations.find((c) => c.fullName.toLowerCase().includes(search.toLowerCase()));
 
-		if (conversation) {
-			setSelectedConversation(conversation);
-			setSearch("");
-		} else toast.error("No such user found!");
-	};
-	return (
-		<form onSubmit={handleSubmit} className='flex items-center gap-2'>
-			<input
-				type='text'
-				placeholder='Search…'
-				className='input input-bordered rounded-full'
-				value={search}
-				onChange={(e) => setSearch(e.target.value)}
-			/>
-			<button type='submit' className='btn btn-circle bg-sky-500 text-white'>
-				<IoSearchSharp className='w-6 h-6 outline-none' />
-			</button>
-		</form>
-	);
+        if (conversation) {
+            setSelectedConversation(conversation);
+        } else {
+            toast.error("No such user found!");
+        }
+        
+        setSearch("");
+    };
+    
+    return (
+        <form onSubmit={handleSubmit} className='flex items-center gap-2'>
+            <input
+                type='text'
+                placeholder='Search…'
+                className='input input-bordered rounded-full bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+            />
+            <button type='submit' className='btn btn-circle bg-sky-500 text-white dark:bg-sky-600'>
+                <IoSearchSharp className='w-6 h-6 outline-none' />
+            </button>
+        </form>
+    );
 };
 export default SearchInput;
-
-// STARTER CODE SNIPPET
-// import { IoSearchSharp } from "react-icons/io5";
-
-// const SearchInput = () => {
-// 	return (
-// 		<form className='flex items-center gap-2'>
-// 			<input type='text' placeholder='Search…' className='input input-bordered rounded-full' />
-// 			<button type='submit' className='btn btn-circle bg-sky-500 text-white'>
-// 				<IoSearchSharp className='w-6 h-6 outline-none' />
-// 			</button>
-// 		</form>
-// 	);
-// };
-// export default SearchInput;

--- a/frontend/src/components/sidebar/Sidebar.jsx
+++ b/frontend/src/components/sidebar/Sidebar.jsx
@@ -1,32 +1,19 @@
 import Conversations from "./Conversations";
 import LogoutButton from "./LogoutButton";
 import SearchInput from "./SearchInput";
+import ThemeToggle from "../ThemeToggle";
 
 const Sidebar = () => {
-	return (
-		<div className='border-r border-slate-500 p-4 flex flex-col'>
-			<SearchInput />
-			<div className='divider px-3'></div>
-			<Conversations />
-			<LogoutButton />
-		</div>
-	);
+    return (
+        <div className='border-r border-slate-500 p-4 flex flex-col text-gray-800 dark:text-gray-200'>
+            <SearchInput />
+            <div className='divider px-3'></div>
+            <Conversations />
+            <div className='mt-auto flex items-center justify-between'>
+                <LogoutButton />
+                <ThemeToggle />
+            </div>
+        </div>
+    );
 };
 export default Sidebar;
-
-// STARTER CODE FOR THIS FILE
-// import Conversations from "./Conversations";
-// import LogoutButton from "./LogoutButton";
-// import SearchInput from "./SearchInput";
-
-// const Sidebar = () => {
-// 	return (
-// 		<div className='border-r border-slate-500 p-4 flex flex-col'>
-// 			<SearchInput />
-// 			<div className='divider px-3'></div>
-// 			<Conversations />
-// 			<LogoutButton />
-// 		</div>
-// 	);
-// };
-// export default Sidebar;

--- a/frontend/src/components/skeletons/MessageSkeleton.jsx
+++ b/frontend/src/components/skeletons/MessageSkeleton.jsx
@@ -1,20 +1,20 @@
 const MessageSkeleton = () => {
-	return (
-		<>
-			<div className='flex gap-3 items-center'>
-				<div className='skeleton w-10 h-10 rounded-full shrink-0'></div>
-				<div className='flex flex-col gap-1'>
-					<div className='skeleton h-4 w-40'></div>
-					<div className='skeleton h-4 w-40'></div>
-				</div>
-			</div>
-			<div className='flex gap-3 items-center justify-end'>
-				<div className='flex flex-col gap-1'>
-					<div className='skeleton h-4 w-40'></div>
-				</div>
-				<div className='skeleton w-10 h-10 rounded-full shrink-0'></div>
-			</div>
-		</>
-	);
+    return (
+        <>
+            <div className='flex gap-3 items-center'>
+                <div className='skeleton w-10 h-10 rounded-full shrink-0 bg-gray-300 dark:bg-gray-700'></div>
+                <div className='flex flex-col gap-1'>
+                    <div className='skeleton h-4 w-40 bg-gray-300 dark:bg-gray-700'></div>
+                    <div className='skeleton h-4 w-40 bg-gray-300 dark:bg-gray-700'></div>
+                </div>
+            </div>
+            <div className='flex gap-3 items-center justify-end'>
+                <div className='flex flex-col gap-1'>
+                    <div className='skeleton h-4 w-40 bg-gray-300 dark:bg-gray-700'></div>
+                </div>
+                <div className='skeleton w-10 h-10 rounded-full shrink-0 bg-gray-300 dark:bg-gray-700'></div>
+            </div>
+        </>
+    );
 };
 export default MessageSkeleton;

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,23 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+export const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(localStorage.getItem('theme') || 'light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,15 +5,18 @@ import "./index.css";
 import { BrowserRouter } from "react-router-dom";
 import { AuthContextProvider } from "./context/AuthContext.jsx";
 import { SocketContextProvider } from "./context/SocketContext.jsx";
+import { ThemeProvider } from "./context/ThemeContext.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-	<React.StrictMode>
-		<BrowserRouter>
-			<AuthContextProvider>
-				<SocketContextProvider>
-					<App />
-				</SocketContextProvider>
-			</AuthContextProvider>
-		</BrowserRouter>
-	</React.StrictMode>
+    <React.StrictMode>
+        <BrowserRouter>
+            <AuthContextProvider>
+                <SocketContextProvider>
+                    <ThemeProvider>
+                        <App />
+                    </ThemeProvider>
+                </SocketContextProvider>
+            </AuthContextProvider>
+        </BrowserRouter>
+    </React.StrictMode>
 );

--- a/frontend/src/pages/ForgotPassword/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword/ForgotPassword.jsx
@@ -48,7 +48,7 @@ const ForgotPassword = () => {
 
     return (
         <>
-            <h1 className="text-3xl font-semibold text-center text-gray-800 dark:text-gray-200">
+            <h1 className="text-3xl font-semibold text-center text-gray-800 dark:text-gray-200 mt-8">
                 Forgot Password
                 <span className="text-blue-500"> ChitChat</span>
             </h1>

--- a/frontend/src/pages/ForgotPassword/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword/ForgotPassword.jsx
@@ -4,183 +4,143 @@ import toast from "react-hot-toast";
 import useForgotPassword from "../../hooks/useForgotPassword";
 
 const ForgotPassword = () => {
-  const [email, setEmail] = useState("");
-  const [otp, setOtp] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
+    const [email, setEmail] = useState("");
+    const [otp, setOtp] = useState("");
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
 
-  const navigate = useNavigate();
-  const { loading, otpSent, sendOtp, resetPassword, setOtpSent } =
-    useForgotPassword();
+    const navigate = useNavigate();
+    const { loading, otpSent, sendOtp, resetPassword, setOtpSent } = useForgotPassword();
 
-  // Send OTP
-  const handleSendOtp = async (e) => {
-    e.preventDefault();
-    if (!email) {
-      toast.error("Please enter your email");
-      return;
-    }
-    await sendOtp(email);
-  };
+    const handleSendOtp = async (e) => {
+        e.preventDefault();
+        if (!email) {
+            toast.error("Please enter your email");
+            return;
+        }
+        await sendOtp(email);
+    };
 
-  // Reset Password with validation
-  const handleResetPassword = async (e) => {
-    e.preventDefault();
+    const handleResetPassword = async (e) => {
+        e.preventDefault();
+        if (!otp || !newPassword || !confirmPassword) {
+            toast.error("Please fill all fields");
+            return;
+        }
+        if (newPassword !== confirmPassword) {
+            toast.error("Passwords do not match");
+            return;
+        }
+        const success = await resetPassword({ email, otp, newPassword, confirmPassword });
+        if (success) {
+            toast.success("Password reset successful!");
+            navigate("/login");
+        }
+    };
 
-    // Validation checks
-    if (!otp || !newPassword || !confirmPassword) {
-      toast.error("Please fill all fields");
-      return;
-    }
+    const handleResendOtp = async () => {
+        if (!email) {
+            toast.error("Please enter your email");
+            return;
+        }
+        await sendOtp(email);
+    };
 
-    if (newPassword !== confirmPassword) {
-      toast.error("Passwords do not match");
-      return;
-    }
+    return (
+        <>
+            <h1 className="text-3xl font-semibold text-center text-gray-800 dark:text-gray-200">
+                Forgot Password
+                <span className="text-blue-500"> ChitChat</span>
+            </h1>
 
-    // Call hook's resetPassword
-    const success = await resetPassword({ email, otp, newPassword, confirmPassword });
+            <form className="mt-4">
+                <div>
+                    <label className="label p-2">
+                        <span className="text-base label-text text-gray-800 dark:text-gray-200">Email</span>
+                    </label>
+                    <input
+                        type="email"
+                        placeholder="Enter your email"
+                        className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        disabled={otpSent}
+                    />
+                </div>
 
-    if (success) {
-      toast.success("Password reset successful!");
-      navigate("/login");
-    }
-  };
+                {otpSent && (
+                    <>
+                        <div className="mt-4">
+                            <label className="label p-2">
+                                <span className="text-base label-text text-gray-800 dark:text-gray-200">OTP</span>
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="Enter OTP"
+                                className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                                value={otp}
+                                onChange={(e) => setOtp(e.target.value)}
+                                required
+                            />
+                        </div>
+                        <div className="mt-2">
+                            <label className="label p-2">
+                                <span className="text-base label-text text-gray-800 dark:text-gray-200">New Password</span>
+                            </label>
+                            <input
+                                type="password"
+                                placeholder="Enter New Password"
+                                className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                                value={newPassword}
+                                onChange={(e) => setNewPassword(e.target.value)}
+                                required
+                            />
+                        </div>
+                        <div className="mt-2">
+                            <label className="label p-2">
+                                <span className="text-base label-text text-gray-800 dark:text-gray-200">Confirm Password</span>
+                            </label>
+                            <input
+                                type="password"
+                                placeholder="Confirm New Password"
+                                className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                                value={confirmPassword}
+                                onChange={(e) => setConfirmPassword(e.target.value)}
+                                required
+                            />
+                        </div>
+                    </>
+                )}
 
-  const handleResendOtp = async () => {
-    if (!email) {
-      toast.error("Please enter your email");
-      return;
-    }
-    await sendOtp(email);
-  };
+                <div className="flex justify-between mt-4 gap-2">
+                    {!otpSent ? (
+                        <button className="btn btn-block btn-sm bg-sky-500 text-white dark:bg-sky-600" onClick={handleSendOtp} disabled={loading}>
+                            {loading ? <span className="loading loading-spinner"></span> : "Send OTP"}
+                        </button>
+                    ) : (
+                        <>
+                            <button className="btn btn-outline btn-sm flex-1 dark:text-white dark:border-gray-400 dark:hover:bg-gray-700" onClick={handleResendOtp} disabled={loading} type="button">
+                                {loading ? <span className="loading loading-spinner"></span> : "Resend OTP"}
+                            </button>
+                            <button className="btn btn-sm bg-sky-500 text-white dark:bg-sky-600 flex-1" onClick={handleResetPassword} disabled={loading} type="button">
+                                {loading ? <span className="loading loading-spinner"></span> : "Set Password"}
+                            </button>
+                        </>
+                    )}
+                </div>
 
-  return (
-    <div className="flex flex-col items-center justify-center min-w-96 mx-auto">
-      <div className="w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0">
-        <h1 className="text-3xl font-semibold text-center text-gray-300">
-          Forgot Password
-          <span className="text-black"> ChitChat</span>
-        </h1>
-
-        <form className="mt-4">
-          {/* Email input */}
-          <div>
-            <label className="label p-2">
-              <span className="text-base label-text">Email</span>
-            </label>
-            <input
-              type="email"
-              placeholder="Enter your email"
-              className="w-full input input-bordered h-10"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              disabled={otpSent}
-            />
-          </div>
-
-          {/* OTP + Password fields */}
-          {otpSent && (
-            <>
-              <div className="mt-4">
-                <label className="label p-2">
-                  <span className="text-base label-text">OTP</span>
-                </label>
-                <input
-                  type="text"
-                  placeholder="Enter OTP"
-                  className="w-full input input-bordered h-10"
-                  value={otp}
-                  onChange={(e) => setOtp(e.target.value)}
-                  required
-                />
-              </div>
-
-              <div className="mt-2">
-                <label className="label p-2">
-                  <span className="text-base label-text">New Password</span>
-                </label>
-                <input
-                  type="password"
-                  placeholder="Enter New Password"
-                  className="w-full input input-bordered h-10"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  required
-                />
-              </div>
-
-              <div className="mt-2">
-                <label className="label p-2">
-                  <span className="text-base label-text">Confirm Password</span>
-                </label>
-                <input
-                  type="password"
-                  placeholder="Confirm New Password"
-                  className="w-full input input-bordered h-10"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  required
-                />
-              </div>
-            </>
-          )}
-
-          {/* Buttons */}
-          <div className="flex justify-between mt-4 gap-2">
-            {!otpSent ? (
-              <button
-                className="btn btn-block btn-sm hover:bg-blue-600 hover:text-white transition-colors"
-                onClick={handleSendOtp}
-                disabled={loading}
-              >
-                {loading ? <span className="loading loading-spinner"></span> : "Send OTP"}
-              </button>
-            ) : (
-              <>
-                <button
-                  className="btn btn-outline btn-sm flex-1 hover:bg-blue-100 hover:text-blue-700 transition-colors"
-                  onClick={handleResendOtp}
-                  disabled={loading}
-                  type="button"
-                >
-                  {loading ? <span className="loading loading-spinner"></span> : "Resend OTP"}
-                </button>
-
-                <button
-                  className="btn btn-sm hover:bg-blue-600 hover:text-white transition-colors"
-                  style={{ width: "37%" }}
-                  onClick={handleResetPassword}
-                  disabled={loading}
-                  type="button"
-                >
-                  {loading ? <span className="loading loading-spinner"></span> : "Set Password"}
-                </button>
-              </>
-            )}
-          </div>
-
-          {/* Links */}
-          <div className="flex justify-between items-center mt-4">
-            <Link
-              to="/login"
-              className="text-sm hover:underline hover:text-blue-600"
-              onClick={() => setOtpSent(false)}
-            >
-              Back to Login
-            </Link>
-            <Link
-              to="/signup"
-              className="text-sm hover:underline hover:text-blue-600"
-            >
-              {"Don't"} have an account?
-            </Link>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
+                <div className="flex justify-between items-center mt-4">
+                    <Link to="/login" className="text-sm hover:underline hover:text-blue-600 text-gray-800 dark:text-gray-200" onClick={() => setOtpSent(false)}>
+                        Back to Login
+                    </Link>
+                    <Link to="/signup" className="text-sm hover:underline hover:text-blue-600 text-gray-800 dark:text-gray-200">
+                        {"Don't"} have an account?
+                    </Link>
+                </div>
+            </form>
+        </>
+    );
 };
 
 export default ForgotPassword;

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -2,11 +2,11 @@ import MessageContainer from "../../components/messages/MessageContainer";
 import Sidebar from "../../components/sidebar/Sidebar";
 
 const Home = () => {
-	return (
-		<div className='flex sm:h-[450px] md:h-[550px] rounded-lg overflow-hidden bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0'>
-			<Sidebar />
-			<MessageContainer />
-		</div>
-	);
+    return (
+        <div className='flex sm:h-[450px] md:h-[550px] rounded-lg overflow-hidden bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0 dark:bg-gray-900/50'>
+            <Sidebar />
+            <MessageContainer />
+        </div>
+    );
 };
 export default Home;

--- a/frontend/src/pages/login/Login.jsx
+++ b/frontend/src/pages/login/Login.jsx
@@ -1,129 +1,79 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import useLogin from "../../hooks/useLogin";
+import ThemeToggle from "../../components/ThemeToggle";
 
 const Login = () => {
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const { loading, login } = useLogin();
 
-  const { loading, login } = useLogin();
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        await login(username, password);
+    };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    await login(username, password);
-  };
+    return (
+        <div className="flex flex-col items-center justify-center min-w-96 mx-auto">
+            <div className="w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0 dark:bg-black/30 relative">
+                <div className="absolute top-4 right-4">
+                    <ThemeToggle />
+                </div>
+                <h1 className="text-3xl font-semibold text-center text-gray-800 dark:text-gray-200">
+                    Login
+                    <span className="text-blue-500"> ChitChat</span>
+                </h1>
 
-  return (
-    <div className="flex flex-col items-center justify-center min-w-96 mx-auto">
-      <div className="w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0">
-        <h1 className="text-3xl font-semibold text-center text-gray-300">
-          Login
-          <span className="text-black"> ChitChat</span>
-        </h1>
+                <form onSubmit={handleSubmit}>
+                    <div>
+                        <label className="label p-2">
+                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Username</span>
+                        </label>
+                        <input
+                            type="text"
+                            placeholder="Enter username"
+                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                            value={username}
+                            onChange={(e) => setUsername(e.target.value)}
+                        />
+                    </div>
 
-        <form onSubmit={handleSubmit}>
-          <div>
-            <label className="label p-2">
-              <span className="text-base label-text">Username</span>
-            </label>
-            <input
-              type="text"
-              placeholder="Enter username"
-              className="w-full input input-bordered h-10"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-            />
-          </div>
+                    <div>
+                        <label className="label">
+                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Password</span>
+                        </label>
+                        <input
+                            type="password"
+                            placeholder="Enter Password"
+                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                        />
+                    </div>
 
-          <div>
-            <label className="label">
-              <span className="text-base label-text">Password</span>
-            </label>
-            <input
-              type="password"
-              placeholder="Enter Password"
-              className="w-full input input-bordered h-10"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </div>
-          {/* <Link
-            to="/signup"
-            className="text-sm  hover:underline hover:text-blue-600 mt-2 inline-block"
-          >
-            {"Don't"} have an account?
-          </Link> */}
+                    <div className="flex justify-between items-center mt-2">
+                        <Link
+                            to="/forgot-password"
+                            className="text-sm hover:underline hover:text-blue-600 text-gray-800 dark:text-gray-200"
+                        >
+                            Forgot Password?
+                        </Link>
+                        <Link
+                            to="/signup"
+                            className="text-sm hover:underline hover:text-blue-600 text-gray-800 dark:text-gray-200"
+                        >
+                            {"Don't"} have an account?
+                        </Link>
+                    </div>
 
-           <div className="flex justify-between items-center mt-2">
-            <Link
-              to="/forgot-password"
-              className="text-sm hover:underline hover:text-blue-600"
-            >
-              Forgot Password?
-            </Link>
-
-            <Link
-              to="/signup"
-              className="text-sm hover:underline hover:text-blue-600"
-            >
-              {"Don't"} have an account?
-            </Link>
-          </div>
-
-          <div>
-            <button className="btn btn-block btn-sm mt-2 hover:bg-blue-600 hover:text-white transition-colors" disabled={loading}>
-              {loading ? (
-                <span className="loading loading-spinner "></span>
-              ) : (
-                "Login"
-              )}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
+                    <div>
+                        <button className="btn btn-block btn-sm mt-2 bg-sky-500 text-white dark:bg-sky-600" disabled={loading}>
+                            {loading ? <span className="loading loading-spinner "></span> : "Login"}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
 };
 export default Login;
-
-// STARTER CODE FOR THIS FILE
-// const Login = () => {
-// 	return (
-// 		<div className='flex flex-col items-center justify-center min-w-96 mx-auto'>
-// 			<div className='w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0'>
-// 				<h1 className='text-3xl font-semibold text-center text-gray-300'>
-// 					Login
-// 					<span className='text-blue-500'> ChatApp</span>
-// 				</h1>
-
-// 				<form>
-// 					<div>
-// 						<label className='label p-2'>
-// 							<span className='text-base label-text'>Username</span>
-// 						</label>
-// 						<input type='text' placeholder='Enter username' className='w-full input input-bordered h-10' />
-// 					</div>
-
-// 					<div>
-// 						<label className='label'>
-// 							<span className='text-base label-text'>Password</span>
-// 						</label>
-// 						<input
-// 							type='password'
-// 							placeholder='Enter Password'
-// 							className='w-full input input-bordered h-10'
-// 						/>
-// 					</div>
-// 					<a href='#' className='text-sm  hover:underline hover:text-blue-600 mt-2 inline-block'>
-// 						{"Don't"} have an account?
-// 					</a>
-
-// 					<div>
-// 						<button className='btn btn-block btn-sm mt-2'>Login</button>
-// 					</div>
-// 				</form>
-// 			</div>
-// 		</div>
-// 	);
-// };
-// export default Login;

--- a/frontend/src/pages/login/Login.jsx
+++ b/frontend/src/pages/login/Login.jsx
@@ -1,79 +1,70 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import useLogin from "../../hooks/useLogin";
-import ThemeToggle from "../../components/ThemeToggle";
 
 const Login = () => {
-    const [username, setUsername] = useState("");
-    const [password, setPassword] = useState("");
-    const { loading, login } = useLogin();
+	const [username, setUsername] = useState("");
+	const [password, setPassword] = useState("");
+	const { loading, login } = useLogin();
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        await login(username, password);
-    };
+	const handleSubmit = async (e) => {
+		e.preventDefault();
+		await login(username, password);
+	};
 
-    return (
-        <div className="flex flex-col items-center justify-center min-w-96 mx-auto">
-            <div className="w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0 dark:bg-black/30 relative">
-                <div className="absolute top-4 right-4">
-                    <ThemeToggle />
-                </div>
-                <h1 className="text-3xl font-semibold text-center text-gray-800 dark:text-gray-200">
-                    Login
-                    <span className="text-blue-500"> ChitChat</span>
-                </h1>
+	return (
+		<>
+			<h1 className='text-3xl font-semibold text-center text-gray-800 dark:text-gray-200'>
+				Login
+				<span className='text-blue-500'> ChitChat</span>
+			</h1>
 
-                <form onSubmit={handleSubmit}>
-                    <div>
-                        <label className="label p-2">
-                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Username</span>
-                        </label>
-                        <input
-                            type="text"
-                            placeholder="Enter username"
-                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
-                            value={username}
-                            onChange={(e) => setUsername(e.target.value)}
-                        />
-                    </div>
+			<form onSubmit={handleSubmit} className='mt-6'>
+				<div>
+					<label className='label p-2'>
+						<span className='text-base label-text text-gray-800 dark:text-gray-200'>Username</span>
+					</label>
+					<input
+						type='text'
+						placeholder='Enter username'
+						className='w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+						value={username}
+						onChange={(e) => setUsername(e.target.value)}
+					/>
+				</div>
 
-                    <div>
-                        <label className="label">
-                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Password</span>
-                        </label>
-                        <input
-                            type="password"
-                            placeholder="Enter Password"
-                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                        />
-                    </div>
+				<div>
+					<label className='label mt-2'>
+						<span className='text-base label-text text-gray-800 dark:text-gray-200'>Password</span>
+					</label>
+					<input
+						type='password'
+						placeholder='Enter Password'
+						className='w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+						value={password}
+						onChange={(e) => setPassword(e.target.value)}
+					/>
+				</div>
 
-                    <div className="flex justify-between items-center mt-2">
-                        <Link
-                            to="/forgot-password"
-                            className="text-sm hover:underline hover:text-blue-600 text-gray-800 dark:text-gray-200"
-                        >
-                            Forgot Password?
-                        </Link>
-                        <Link
-                            to="/signup"
-                            className="text-sm hover:underline hover:text-blue-600 text-gray-800 dark:text-gray-200"
-                        >
-                            {"Don't"} have an account?
-                        </Link>
-                    </div>
+				<div className='flex justify-between items-center mt-4'>
+					<Link
+						to='/forgot-password'
+						className='text-sm hover:underline hover:text-blue-600 text-gray-800 dark:text-gray-200'
+					>
+						Forgot Password?
+					</Link>
+					<Link to='/signup' className='text-sm hover:underline hover:text-blue-600 text-gray-800 dark:text-gray-200'>
+						{"Don't"} have an account?
+					</Link>
+				</div>
 
-                    <div>
-                        <button className="btn btn-block btn-sm mt-2 bg-sky-500 text-white dark:bg-sky-600" disabled={loading}>
-                            {loading ? <span className="loading loading-spinner "></span> : "Login"}
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    );
+				<div>
+					<button className='btn btn-block btn-sm mt-4 bg-sky-500 text-white dark:bg-sky-600' disabled={loading}>
+						{loading ? <span className='loading loading-spinner '></span> : "Login"}
+					</button>
+				</div>
+			</form>
+		</>
+	);
 };
 export default Login;

--- a/frontend/src/pages/signup/GenderCheckbox.jsx
+++ b/frontend/src/pages/signup/GenderCheckbox.jsx
@@ -1,50 +1,50 @@
 const GenderCheckbox = ({ onCheckboxChange, selectedGender }) => {
-	return (
-		<div className='flex'>
-			<div className='form-control'>
-				<label className={`label gap-2 cursor-pointer ${selectedGender === "male" ? "selected" : ""} `}>
-					<span className='label-text'>Male</span>
-					<input
-						type='checkbox'
-						className='checkbox border-slate-900'
-						checked={selectedGender === "male"}
-						onChange={() => onCheckboxChange("male")}
-					/>
-				</label>
-			</div>
-			<div className='form-control'>
-				<label className={`label gap-2 cursor-pointer  ${selectedGender === "female" ? "selected" : ""}`}>
-					<span className='label-text'>Female</span>
-					<input
-						type='checkbox'
-						className='checkbox border-slate-900'
-						checked={selectedGender === "female"}
-						onChange={() => onCheckboxChange("female")}
-					/>
-				</label>
-			</div>
-		</div>
-	);
+    return (
+        <div className='flex'>
+            <div className='form-control'>
+                <label className={`label gap-2 cursor-pointer ${selectedGender === "male" ? "selected" : ""} `}>
+                    <span className='label-text text-gray-800 dark:text-gray-200'>Male</span>
+                    <input
+                        type='checkbox'
+                        className='checkbox border-slate-900 dark:border-slate-400'
+                        checked={selectedGender === "male"}
+                        onChange={() => onCheckboxChange("male")}
+                    />
+                </label>
+            </div>
+            <div className='form-control'>
+                <label className={`label gap-2 cursor-pointer  ${selectedGender === "female" ? "selected" : ""}`}>
+                    <span className='label-text text-gray-800 dark:text-gray-200'>Female</span>
+                    <input
+                        type='checkbox'
+                        className='checkbox border-slate-900 dark:border-slate-400'
+                        checked={selectedGender === "female"}
+                        onChange={() => onCheckboxChange("female")}
+                    />
+                </label>
+            </div>
+        </div>
+    );
 };
 export default GenderCheckbox;
 
 // STARTER CODE FOR THIS FILE
 // const GenderCheckbox = () => {
-// 	return (
-// 		<div className='flex'>
-// 			<div className='form-control'>
-// 				<label className={`label gap-2 cursor-pointer`}>
-// 					<span className='label-text'>Male</span>
-// 					<input type='checkbox' className='checkbox border-slate-900' />
-// 				</label>
-// 			</div>
-// 			<div className='form-control'>
-// 				<label className={`label gap-2 cursor-pointer`}>
-// 					<span className='label-text'>Female</span>
-// 					<input type='checkbox' className='checkbox border-slate-900' />
-// 				</label>
-// 			</div>
-// 		</div>
-// 	);
+//  return (
+//      <div className='flex'>
+//          <div className='form-control'>
+//              <label className={`label gap-2 cursor-pointer`}>
+//                  <span className='label-text'>Male</span>
+//                  <input type='checkbox' className='checkbox border-slate-900' />
+//              </label>
+//          </div>
+//          <div className='form-control'>
+//              <label className={`label gap-2 cursor-pointer`}>
+//                  <span className='label-text'>Female</span>
+//                  <input type='checkbox' className='checkbox border-slate-900' />
+//              </label>
+//          </div>
+//      </div>
+//  );
 // };
 // export default GenderCheckbox;

--- a/frontend/src/pages/signup/SignUp.jsx
+++ b/frontend/src/pages/signup/SignUp.jsx
@@ -2,128 +2,116 @@ import { Link } from "react-router-dom";
 import GenderCheckbox from "./GenderCheckbox";
 import { useState } from "react";
 import useSignup from "../../hooks/useSignup";
-import ThemeToggle from "../../components/ThemeToggle";
 
 const SignUp = () => {
-    const [inputs, setInputs] = useState({
-        fullName: "",
-        email: "",
-        username: "",
-        password: "",
-        confirmPassword: "",
-        gender: "",
-    });
+	const [inputs, setInputs] = useState({
+		fullName: "",
+		email: "",
+		username: "",
+		password: "",
+		confirmPassword: "",
+		gender: "",
+	});
 
-    const { loading, signup } = useSignup();
+	const { loading, signup } = useSignup();
 
-    const handleCheckboxChange = (gender) => {
-        setInputs({ ...inputs, gender });
-    };
+	const handleCheckboxChange = (gender) => {
+		setInputs({ ...inputs, gender });
+	};
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        await signup(inputs);
-    };
+	const handleSubmit = async (e) => {
+		e.preventDefault();
+		await signup(inputs);
+	};
 
-    return (
-        <div className="flex flex-col items-center justify-center min-w-96 mx-auto">
-            <div className="w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0 dark:bg-black/30 relative">
-                <div className="absolute top-4 right-4">
-                    <ThemeToggle />
-                </div>
-                <h1 className="text-3xl font-semibold text-center text-gray-800 dark:text-gray-200">
-                    Sign Up <span className="text-blue-500"> ChitChat</span>
-                </h1>
+	return (
+		<>
+			<h1 className='text-3xl font-semibold text-center text-gray-800 dark:text-gray-200'>
+				Sign Up <span className='text-blue-500'> ChitChat</span>
+			</h1>
 
-                <form onSubmit={handleSubmit}>
-                    <div>
-                        <label className="label p-2">
-                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Full Name</span>
-                        </label>
-                        <input
-                            type="text"
-                            placeholder="John Doe"
-                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
-                            value={inputs.fullName}
-                            onChange={(e) => setInputs({ ...inputs, fullName: e.target.value })}
-                        />
-                    </div>
+			<form onSubmit={handleSubmit} className='mt-6'>
+				<div>
+					<label className='label p-2'>
+						<span className='text-base label-text text-gray-800 dark:text-gray-200'>Full Name</span>
+					</label>
+					<input
+						type='text'
+						placeholder='John Doe'
+						className='w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+						value={inputs.fullName}
+						onChange={(e) => setInputs({ ...inputs, fullName: e.target.value })}
+					/>
+				</div>
 
-                    <div>
-                        <label className="label p-2 ">
-                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Username</span>
-                        </label>
-                        <input
-                            type="text"
-                            placeholder="johndoe"
-                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
-                            value={inputs.username}
-                            onChange={(e) => setInputs({ ...inputs, username: e.target.value })}
-                        />
-                    </div>
+				<div>
+					<label className='label p-2 '>
+						<span className='text-base label-text text-gray-800 dark:text-gray-200'>Username</span>
+					</label>
+					<input
+						type='text'
+						placeholder='johndoe'
+						className='w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+						value={inputs.username}
+						onChange={(e) => setInputs({ ...inputs, username: e.target.value })}
+					/>
+				</div>
 
-                    <div>
-                        <label className="label p-2 ">
-                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Email</span>
-                        </label>
-                        <input
-                            type="email"
-                            placeholder="you@example.com"
-                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
-                            value={inputs.email}
-                            onChange={(e) => setInputs({ ...inputs, email: e.target.value })}
-                        />
-                    </div>
+				<div>
+					<label className='label p-2 '>
+						<span className='text-base label-text text-gray-800 dark:text-gray-200'>Email</span>
+					</label>
+					<input
+						type='email'
+						placeholder='you@example.com'
+						className='w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+						value={inputs.email}
+						onChange={(e) => setInputs({ ...inputs, email: e.target.value })}
+					/>
+				</div>
 
-                    <div>
-                        <label className="label">
-                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Password</span>
-                        </label>
-                        <input
-                            type="password"
-                            placeholder="Enter Password"
-                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
-                            value={inputs.password}
-                            onChange={(e) => setInputs({ ...inputs, password: e.target.value })}
-                        />
-                    </div>
+				<div>
+					<label className='label'>
+						<span className='text-base label-text text-gray-800 dark:text-gray-200'>Password</span>
+					</label>
+					<input
+						type='password'
+						placeholder='Enter Password'
+						className='w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+						value={inputs.password}
+						onChange={(e) => setInputs({ ...inputs, password: e.target.value })}
+					/>
+				</div>
 
-                    <div>
-                        <label className="label">
-                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Confirm Password</span>
-                        </label>
-                        <input
-                            type="password"
-                            placeholder="Confirm Password"
-                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
-                            value={inputs.confirmPassword}
-                            onChange={(e) => setInputs({ ...inputs, confirmPassword: e.target.value })}
-                        />
-                    </div>
+				<div>
+					<label className='label'>
+						<span className='text-base label-text text-gray-800 dark:text-gray-200'>Confirm Password</span>
+					</label>
+					<input
+						type='password'
+						placeholder='Confirm Password'
+						className='w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+						value={inputs.confirmPassword}
+						onChange={(e) => setInputs({ ...inputs, confirmPassword: e.target.value })}
+					/>
+				</div>
 
-                    <GenderCheckbox
-                        onCheckboxChange={handleCheckboxChange}
-                        selectedGender={inputs.gender}
-                    />
+				<GenderCheckbox onCheckboxChange={handleCheckboxChange} selectedGender={inputs.gender} />
 
-                    <Link
-                        to={"/login"}
-                        className="text-sm hover:underline hover:text-blue-600 mt-2 inline-block text-gray-800 dark:text-gray-200"
-                    >
-                        Already have an account?
-                    </Link>
+				<Link
+					to={"/login"}
+					className='text-sm hover:underline hover:text-blue-600 mt-2 inline-block text-gray-800 dark:text-gray-200'
+				>
+					Already have an account?
+				</Link>
 
-                    <div>
-                        <button
-                            className="btn btn-block btn-sm mt-2 border border-slate-700 bg-sky-500 text-white dark:bg-sky-600"
-                            disabled={loading}
-                        >
-                            {loading ? <span className="loading loading-spinner"></span> : "Sign Up"}
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    );
+				<div>
+					<button className='btn btn-block btn-sm mt-2 border border-slate-700 bg-sky-500 text-white dark:bg-sky-600' disabled={loading}>
+						{loading ? <span className='loading loading-spinner'></span> : "Sign Up"}
+					</button>
+				</div>
+			</form>
+		</>
+	);
 };
 export default SignUp;

--- a/frontend/src/pages/signup/SignUp.jsx
+++ b/frontend/src/pages/signup/SignUp.jsx
@@ -2,201 +2,128 @@ import { Link } from "react-router-dom";
 import GenderCheckbox from "./GenderCheckbox";
 import { useState } from "react";
 import useSignup from "../../hooks/useSignup";
+import ThemeToggle from "../../components/ThemeToggle";
 
 const SignUp = () => {
-  const [inputs, setInputs] = useState({
-    fullName: "",
-    email: "",
-    username: "",
-    password: "",
-    confirmPassword: "",
-    gender: "",
-  });
+    const [inputs, setInputs] = useState({
+        fullName: "",
+        email: "",
+        username: "",
+        password: "",
+        confirmPassword: "",
+        gender: "",
+    });
 
-  const { loading, signup } = useSignup();
+    const { loading, signup } = useSignup();
 
-  const handleCheckboxChange = (gender) => {
-    setInputs({ ...inputs, gender });
-  };
+    const handleCheckboxChange = (gender) => {
+        setInputs({ ...inputs, gender });
+    };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    await signup(inputs);
-  };
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        await signup(inputs);
+    };
 
-  return (
-    <div className="flex flex-col items-center justify-center min-w-96 mx-auto">
-      <div className="w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0">
-        <h1 className="text-3xl font-semibold text-center text-gray-300">
-          Sign Up <span className="text-black"> ChitChat</span>
-        </h1>
+    return (
+        <div className="flex flex-col items-center justify-center min-w-96 mx-auto">
+            <div className="w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0 dark:bg-black/30 relative">
+                <div className="absolute top-4 right-4">
+                    <ThemeToggle />
+                </div>
+                <h1 className="text-3xl font-semibold text-center text-gray-800 dark:text-gray-200">
+                    Sign Up <span className="text-blue-500"> ChitChat</span>
+                </h1>
 
-        <form onSubmit={handleSubmit}>
-          <div>
-            <label className="label p-2">
-              <span className="text-base label-text">Full Name</span>
-            </label>
-            <input
-              type="text"
-              placeholder="John Doe"
-              className="w-full input input-bordered  h-10"
-              value={inputs.fullName}
-              onChange={(e) =>
-                setInputs({ ...inputs, fullName: e.target.value })
-              }
-            />
-          </div>
+                <form onSubmit={handleSubmit}>
+                    <div>
+                        <label className="label p-2">
+                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Full Name</span>
+                        </label>
+                        <input
+                            type="text"
+                            placeholder="John Doe"
+                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                            value={inputs.fullName}
+                            onChange={(e) => setInputs({ ...inputs, fullName: e.target.value })}
+                        />
+                    </div>
 
-          <div>
-            <label className="label p-2 ">
-              <span className="text-base label-text">Username</span>
-            </label>
-            <input
-              type="text"
-              placeholder="johndoe"
-              className="w-full input input-bordered h-10"
-              value={inputs.username}
-              onChange={(e) =>
-                setInputs({ ...inputs, username: e.target.value })
-              }
-            />
-          </div>
+                    <div>
+                        <label className="label p-2 ">
+                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Username</span>
+                        </label>
+                        <input
+                            type="text"
+                            placeholder="johndoe"
+                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                            value={inputs.username}
+                            onChange={(e) => setInputs({ ...inputs, username: e.target.value })}
+                        />
+                    </div>
 
-          <div>
-            <label className="label p-2 ">
-              <span className="text-base label-text">Email</span>
-            </label>
-            <input
-              type="email"
-              placeholder="you@example.com"
-              className="w-full input input-bordered h-10"
-              value={inputs.email}
-              onChange={(e) => setInputs({ ...inputs, email: e.target.value })}
-            />
-          </div>
+                    <div>
+                        <label className="label p-2 ">
+                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Email</span>
+                        </label>
+                        <input
+                            type="email"
+                            placeholder="you@example.com"
+                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                            value={inputs.email}
+                            onChange={(e) => setInputs({ ...inputs, email: e.target.value })}
+                        />
+                    </div>
 
-          <div>
-            <label className="label">
-              <span className="text-base label-text">Password</span>
-            </label>
-            <input
-              type="password"
-              placeholder="Enter Password"
-              className="w-full input input-bordered h-10"
-              value={inputs.password}
-              onChange={(e) =>
-                setInputs({ ...inputs, password: e.target.value })
-              }
-            />
-          </div>
+                    <div>
+                        <label className="label">
+                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Password</span>
+                        </label>
+                        <input
+                            type="password"
+                            placeholder="Enter Password"
+                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                            value={inputs.password}
+                            onChange={(e) => setInputs({ ...inputs, password: e.target.value })}
+                        />
+                    </div>
 
-          <div>
-            <label className="label">
-              <span className="text-base label-text">Confirm Password</span>
-            </label>
-            <input
-              type="password"
-              placeholder="Confirm Password"
-              className="w-full input input-bordered h-10"
-              value={inputs.confirmPassword}
-              onChange={(e) =>
-                setInputs({ ...inputs, confirmPassword: e.target.value })
-              }
-            />
-          </div>
+                    <div>
+                        <label className="label">
+                            <span className="text-base label-text text-gray-800 dark:text-gray-200">Confirm Password</span>
+                        </label>
+                        <input
+                            type="password"
+                            placeholder="Confirm Password"
+                            className="w-full input input-bordered h-10 bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white"
+                            value={inputs.confirmPassword}
+                            onChange={(e) => setInputs({ ...inputs, confirmPassword: e.target.value })}
+                        />
+                    </div>
 
-          <GenderCheckbox
-            onCheckboxChange={handleCheckboxChange}
-            selectedGender={inputs.gender}
-          />
+                    <GenderCheckbox
+                        onCheckboxChange={handleCheckboxChange}
+                        selectedGender={inputs.gender}
+                    />
 
-          <Link
-            to={"/login"}
-            className="text-sm hover:underline hover:text-blue-600 mt-2 inline-block"
-            href="#"
-          >
-            Already have an account?
-          </Link>
+                    <Link
+                        to={"/login"}
+                        className="text-sm hover:underline hover:text-blue-600 mt-2 inline-block text-gray-800 dark:text-gray-200"
+                    >
+                        Already have an account?
+                    </Link>
 
-          <div>
-            <button
-              className="btn btn-block btn-sm mt-2 border border-slate-700 hover:bg-blue-600 hover:text-white transition-colors"
-              disabled={loading}
-            >
-              {loading ? (
-                <span className="loading loading-spinner"></span>
-              ) : (
-                "Sign Up"
-              )}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
+                    <div>
+                        <button
+                            className="btn btn-block btn-sm mt-2 border border-slate-700 bg-sky-500 text-white dark:bg-sky-600"
+                            disabled={loading}
+                        >
+                            {loading ? <span className="loading loading-spinner"></span> : "Sign Up"}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
 };
 export default SignUp;
-
-// STARTER CODE FOR THE SIGNUP COMPONENT
-// import GenderCheckbox from "./GenderCheckbox";
-
-// const SignUp = () => {
-// 	return (
-// 		<div className='flex flex-col items-center justify-center min-w-96 mx-auto'>
-// 			<div className='w-full p-6 rounded-lg shadow-md bg-gray-400 bg-clip-padding backdrop-filter backdrop-blur-lg bg-opacity-0'>
-// 				<h1 className='text-3xl font-semibold text-center text-gray-300'>
-// 					Sign Up <span className='text-blue-500'> ChatApp</span>
-// 				</h1>
-
-// 				<form>
-// 					<div>
-// 						<label className='label p-2'>
-// 							<span className='text-base label-text'>Full Name</span>
-// 						</label>
-// 						<input type='text' placeholder='John Doe' className='w-full input input-bordered  h-10' />
-// 					</div>
-
-// 					<div>
-// 						<label className='label p-2 '>
-// 							<span className='text-base label-text'>Username</span>
-// 						</label>
-// 						<input type='text' placeholder='johndoe' className='w-full input input-bordered h-10' />
-// 					</div>
-
-// 					<div>
-// 						<label className='label'>
-// 							<span className='text-base label-text'>Password</span>
-// 						</label>
-// 						<input
-// 							type='password'
-// 							placeholder='Enter Password'
-// 							className='w-full input input-bordered h-10'
-// 						/>
-// 					</div>
-
-// 					<div>
-// 						<label className='label'>
-// 							<span className='text-base label-text'>Confirm Password</span>
-// 						</label>
-// 						<input
-// 							type='password'
-// 							placeholder='Confirm Password'
-// 							className='w-full input input-bordered h-10'
-// 						/>
-// 					</div>
-
-// 					<GenderCheckbox />
-
-// 					<a className='text-sm hover:underline hover:text-blue-600 mt-2 inline-block' href='#'>
-// 						Already have an account?
-// 					</a>
-
-// 					<div>
-// 						<button className='btn btn-block btn-sm mt-2 border border-slate-700'>Sign Up</button>
-// 					</div>
-// 				</form>
-// 			</div>
-// 		</div>
-// 	);
-// };
-// export default SignUp;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
 	content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+	darkMode: "class",
 	theme: {
 		extend: {},
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,63 +397,6 @@
 				"node": ">=10.2.0"
 			}
 		},
-		"node_modules/engine.io-client": {
-			"version": "6.6.3",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
-			"integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
-			"license": "MIT",
-			"dependencies": {
-				"@socket.io/component-emitter": "~3.1.0",
-				"debug": "~4.3.1",
-				"engine.io-parser": "~5.2.1",
-				"ws": "~8.17.1",
-				"xmlhttprequest-ssl": "~2.1.1"
-			}
-		},
-		"node_modules/engine.io-client/node_modules/debug": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/engine.io-client/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"license": "MIT"
-		},
-		"node_modules/engine.io-client/node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/engine.io-parser": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
@@ -1454,44 +1397,6 @@
 				"ws": "~8.11.0"
 			}
 		},
-		"node_modules/socket.io-client": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
-			"integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@socket.io/component-emitter": "~3.1.0",
-				"debug": "~4.3.2",
-				"engine.io-client": "~6.6.1",
-				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/socket.io-client/node_modules/debug": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/socket.io-client/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"license": "MIT"
-		},
 		"node_modules/socket.io-parser": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -1702,14 +1607,6 @@
 				"utf-8-validate": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/xmlhttprequest-ssl": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-			"integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/yallist": {


### PR DESCRIPTION
 

## Overview  
Introduced a fully integrated dark mode to the ChittChat application. Users can now switch between light and dark themes from any page, with their choice saved in `localStorage` to persist across sessions.  

The goal was to ensure a consistent experience across **all pages and components** while giving users control over their preferred theme.  

## Key Changes  

- **Configuration**  
  - Enabled darkMode: 'class' in `tailwind.config.js`.  

- **Theme Management**  
  - Added a new `ThemeContext` to manage the theme state (`light`/`dark`) globally.  
  - Implemented persistence using `localStorage` so the user’s preference is remembered.  

- **UI Enhancements**  
  - Built a reusable `ThemeToggle` component with sun (☀️) and moon (🌙) icons.  
  - Integrated the toggle into:  
    - `Sidebar` for logged-in users  
    - `Login` and `SignUp` pages for first-time users  

- **Styling Updates**  
  - Applied `dark:` utility classes across the app for a consistent look.  
  - Pages & components styled include:  
    - **Auth**: `Login`, `SignUp`, `GenderCheckbox`  
    - **Main Layout**: `Home`, `App`  
    - **Sidebar**: `Conversation` items, `SearchInput`, `LogoutButton`, loading spinner  
    - **Chat View**: `MessageContainer` + header, `MessageInput`, message bubbles (incoming/outgoing), skeleton loaders  
    - **Notifications**: `react-hot-toast` now auto-matches theme  

- **Bug Fix**  
  - Fixed an issue where the `SearchInput` text did not clear after a failed search.  

## Demo  

https://github.com/user-attachments/assets/70400fd4-416e-4882-bcd3-dcbb2cdfc7ed

Fixed https://github.com/shambhaveesrivastava12/ChittChat/issues/3


