### PR TITLE
create /users/profile endpoint to return logged-in user profile

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -27,3 +27,23 @@ export const getUsersForSidebar = async (req, res) => {
 		res.status(500).json({ error: "Internal server error" });
 	}
 };
+
+
+export const getProfile = async (req, res) => {
+  try {
+    // req.user is populated by authMiddleware
+    const { fullName, email, username, profilePic } = req.user;
+
+	console.log(fullName)
+
+    res.status(200).json({
+      name: fullName,
+      email,
+      avatar: profilePic,
+      username
+    });
+  } catch (error) {
+    console.error("Get Profile Error:", error.message);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+};

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -1,9 +1,10 @@
 import express from "express";
 import protectRoute from "../middleware/protectRoute.js";
-import { getUsersForSidebar } from "../controllers/user.controller.js";
+import { getUsersForSidebar , getProfile } from "../controllers/user.controller.js";
 
 const router = express.Router();
 
 router.get("/", protectRoute, getUsersForSidebar);
+router.get("/profile", protectRoute, getProfile);
 
 export default router;


### PR DESCRIPTION
### What this PR does
- Adds a protected endpoint `/users/profile` to fetch the logged-in user's profile.
- Returns JSON with `name`, `email`, `avatar`, and `username`.
- Relies on `protectRoute` middleware to ensure only authenticated users can access it.

### Why
This endpoint is needed for frontend components (e.g., user sidebar, profile display) to show the logged-in user's information.

### Notes
- If `profilePic` is missing, consider adding a default avatar (like in getUsersForSidebar) for consistency.
