### PR TITLE
add feature: pagination in sidebar

### DIFF
--- a/backend/controllers/conversation.controller.js
+++ b/backend/controllers/conversation.controller.js
@@ -1,0 +1,62 @@
+import mongoose from "mongoose";
+import Conversation from "../models/conversation.model.js";
+import User from "../models/user.model.js"
+export const getConversation = async (req, res) => {
+  try {
+    // get the user name and userId from query parameter
+    const username = req.query?.username // this username is username of the first user in a convo
+    const userId = req.query?.userId // this userId is the userId of the second user in the convo which we will get directly from authContext in frontend
+
+    if(!username || username.trim() === ""){
+      return res.status(400).json({ error: "provide the username" });
+    }
+    if (!userId || userId.trim() === "") {
+      return res.status(400).json({ error: "provide the user id" });
+    }
+
+    // querying the user collection to find user by username
+    const user1Details = await User.findOne({username})
+    if(!user1Details){
+      return res.status(404).json({ error: "user with the provided username not found" });
+    }
+    const user1id = user1Details?._id
+
+    // convert the id strings to mongose objectId and fetch the conversations
+    let user2id;
+    try {
+      user2id = new mongoose.Types.ObjectId(userId);
+    } catch (err) {
+      return res.status(400).json({ error: "Invalid user ID format" });
+    }
+    
+    const user2idExists = await User.findById(user2id) // checking if user 2 exists
+
+    if(!user2idExists){
+      return res.status(404).json({ error: "user 2 does not exist" });
+    }
+
+    let conversation = await Conversation.findOne({
+      participants: { $all: [user1id, user2id] },
+    })
+      .populate("participants", "-password")
+      .populate("messages");
+
+    if(!conversation && user2idExists){// creating a conversation if it does not already exist
+      conversation = await Conversation.create({
+				participants: [user1id, user2id],
+			});
+      conversation = await Conversation.findOne({ // had to specificially find the created conversation otherwise it was causing somme issues
+      participants: { $all: [user1id, user2id] },
+    })
+      .populate("participants", "-password")
+      .populate("messages");
+    }
+    
+    return res.status(200).json({
+      conversation,
+    });
+  } catch (error) {
+    console.error("Error in getConversations: ", error.message);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -1,13 +1,38 @@
+import mongoose from "mongoose";
 import User from "../models/user.model.js";
 
 export const getUsersForSidebar = async (req, res) => {
 	try {
 		const loggedInUserId = req.user._id;
 
-		const filteredUsers = await User.find({ _id: { $ne: loggedInUserId } }).select("-password");
+		// getting the limit and cursor from the req.query object if they are defined the defaults for limit and cursor are 20 and null respectively
+		const limit = parseInt(req.query.limit) || 20
+		const cursor = req.query.cursor ? new mongoose.Types.ObjectId(req.query.cursor) : null;
+
+
+		// building the filter
+		let filter = {
+			_id: { $ne: loggedInUserId }
+		}
+
+		// if the cursor is provided
+		if(cursor){
+			filter._id = {
+				$gt: cursor,
+				$ne: loggedInUserId
+			}
+		}
+
+		const filteredUsers = await User.find(filter)
+										.select("-password")
+										.sort({_id:1})
+										.limit(limit+1)// an extra user is fetched to check if more users are available to be fetched or if this is the last batch of avaiable users
+
+		const hasNextPage = filteredUsers.length > limit 
+		const slicedusers = hasNextPage ? filteredUsers.slice(0,-1) : filteredUsers // remove the extra fetched user
 
 		// Normalize/augment returned users so frontend always has fullName and profilePic
-		const users = filteredUsers.map((u) => {
+		const users = slicedusers.map((u) => {
 			const user = u.toObject();
 			// Prefer existing fullName, then name, then fallback to part of the email
 			user.fullName = user.fullName || user.name || (user.email ? user.email.split("@")[0] : "User");
@@ -21,7 +46,13 @@ export const getUsersForSidebar = async (req, res) => {
 			return user;
 		});
 
-		res.status(200).json(users);
+		// updated the response structure
+		res.status(200).json({
+			users,
+			nextCursor: hasNextPage ? slicedusers[slicedusers.length - 1]._id : null,
+			hasNextPage
+		});
+		
 	} catch (error) {
 		console.error("Error in getUsersForSidebar: ", error.message);
 		res.status(500).json({ error: "Internal server error" });

--- a/backend/routes/conversation.route.js
+++ b/backend/routes/conversation.route.js
@@ -1,0 +1,10 @@
+import express from "express";
+import protectRoute from "../middleware/protectRoute.js";
+import { getConversation } from "../controllers/conversation.controller.js";
+
+
+const router = express.Router();
+
+router.get("/", protectRoute, getConversation);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ import cors from "cors";
 import authRoutes from "./routes/auth.routes.js";
 import messageRoutes from "./routes/message.routes.js";
 import userRoutes from "./routes/user.routes.js";
+import conversationRoutes from "./routes/conversation.route.js"
 
 import connectToMongoDB from "./db/connectToMongoDB.js";
 import { app, server } from "./socket/socket.js";
@@ -57,7 +58,7 @@ app.use(cors(corsOptions));
 app.use("/api/auth", authRoutes);
 app.use("/api/messages", messageRoutes);
 app.use("/api/users", userRoutes);
-
+app.use('/api/conversation',conversationRoutes)
 // Debug endpoint to help diagnose CORS/origin issues. Returns the incoming Origin header and allowed origins.
 app.get("/api/debug/origin", (req, res) => {
 	const incomingOrigin = req.headers.origin || null;

--- a/frontend/src/components/sidebar/Conversations.jsx
+++ b/frontend/src/components/sidebar/Conversations.jsx
@@ -3,21 +3,33 @@ import { getRandomEmoji } from "../../utils/emojis";
 import Conversation from "./Conversation";
 
 const Conversations = () => {
-	const { loading, conversations } = useGetConversations();
-	return (
-		<div className='py-2 flex flex-col overflow-auto'>
-			{conversations.map((conversation, idx) => (
-				<Conversation
-					key={conversation._id}
-					conversation={conversation}
-					emoji={getRandomEmoji()}
-					lastIdx={idx === conversations.length - 1}
-				/>
-			))}
+  const { loading, conversations,loadMore } = useGetConversations(); 
+	// conversations is now an object of the structure {
+	// 	users,
+	// 	nextCursor,
+	// 	hasNextPage
+	// }
 
-			{loading ? <span className='loading loading-spinner mx-auto'></span> : null}
-		</div>
-	);
+  return (
+    <div className="py-2 flex flex-col overflow-auto">
+	  {/* moved the loader up here since errors were being caused in the previous implementation */}
+      {loading ? (
+        <span className="loading loading-spinner mx-auto"></span>
+      ) : (
+        <>
+          {conversations.users.map((conversation, idx) => (
+            <Conversation
+              key={conversation._id}
+              conversation={conversation}
+              emoji={getRandomEmoji()}
+              lastIdx={idx === conversations.users.length - 1}
+            />
+          ))}
+		  {conversations.hasNextPage?<button onClick={loadMore}>Load more</button>:null}
+        </>
+      )}
+    </div>
+  );
 };
 export default Conversations;
 

--- a/frontend/src/components/sidebar/SearchInput.jsx
+++ b/frontend/src/components/sidebar/SearchInput.jsx
@@ -3,25 +3,39 @@ import { IoSearchSharp } from "react-icons/io5";
 import useConversation from "../../zustand/useConversation";
 import useGetConversations from "../../hooks/useGetConversations";
 import toast from "react-hot-toast";
+import { getConversation } from "../../utils/getConversation";
+import { useAuthContext } from "../../context/AuthContext";
 
 const SearchInput = () => {
 	const [search, setSearch] = useState("");
-	const { setSelectedConversation } = useConversation();
+	const { setSelectedConversation,appendConversation } = useConversation();
 	const { conversations } = useGetConversations();
+	const {authUser} = useAuthContext(); // the current user id is to be passed to the getConversation function
+	const userId = authUser?._id
 
-	const handleSubmit = (e) => {
+	const handleSubmit = async (e) => { // making the function async to allow the searching of user
 		e.preventDefault();
 		if (!search) return;
 		if (search.length < 3) {
 			return toast.error("Search term must be at least 3 characters long");
 		}
-
-		const conversation = conversations.find((c) => c.fullName.toLowerCase().includes(search.toLowerCase()));
-
+		if(authUser.username == search){
+			toast.error("cannot initialize conversation with self")
+			return
+		}
+		const conversation = conversations.users.find((c) => c.fullName.toLowerCase().includes(search.toLowerCase())); // updating the use of conversations from useGetConversations hook
 		if (conversation) {
 			setSelectedConversation(conversation);
 			setSearch("");
-		} else toast.error("No such user found!");
+		}else{
+			const data = await getConversation(search.toLowerCase(),userId)
+			const userToappend = data?.conversation?.participants.filter((user)=> user._id != userId )[0]
+			if(!userToappend){
+				toast.error("No such user found!");
+				return
+			}
+			appendConversation(userToappend) // updating zustand store to show the fetched user
+		} 
 	};
 	return (
 		<form onSubmit={handleSubmit} className='flex items-center gap-2'>

--- a/frontend/src/hooks/useGetConversations.js
+++ b/frontend/src/hooks/useGetConversations.js
@@ -1,33 +1,63 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import toast from "react-hot-toast";
+import useConversation from "../zustand/useConversation";
 
-const useGetConversations = () => {
-	const [loading, setLoading] = useState(false);
-	const [conversations, setConversations] = useState([]);
+const useGetConversations = (initialLimit = 1) => { // initial limit set this low for testing purpose only
+  const [loading, setLoading] = useState(true);
+  const { conversations, setConversations } = useConversation();// using zustand store to get conversations
 
-	useEffect(() => {
-		const getConversations = async () => {
-			setLoading(true);
-			try {
-				const API = import.meta.env.VITE_API_URL || "";
-				const token = localStorage.getItem("chat-token");
-				const headers = token ? { Authorization: `Bearer ${token}` } : {};
-				const res = await fetch(`${API}/api/users`, { credentials: "include", headers });
-				const data = await res.json();
-				if (data.error) {
-					throw new Error(data.error);
-				}
-				setConversations(data);
-			} catch (error) {
-				toast.error(error.message);
-			} finally {
-				setLoading(false);
-			}
-		};
+  // creating a fetchConversation function which will be returned by the hook to export the loadMore functionality
+  const fetchConversations = useCallback(async (limit = initialLimit, cursor = "") => {
+    try {
+      setLoading(true);
+      const API = import.meta.env.VITE_API_URL || "";
+      const token = localStorage.getItem("chat-token");
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
-		getConversations();
-	}, []);
+	  // checking if limit is a valid int greater than 0
+	  const parsedLimit = parseInt(limit, 10);
+	  const safeLimit = !isNaN(parsedLimit) && parsedLimit > 0 ? parsedLimit : 2;
 
-	return { loading, conversations };
+	  // building parameters
+      const params = new URLSearchParams();
+      params.set("limit", safeLimit);
+      if (cursor) params.set("cursor", cursor);
+
+      // fetching the convo based on the parameters
+      const res = await fetch(`${API}/api/users?${params.toString()}`, {
+        credentials: "include",
+        headers,
+      });
+      const data = await res.json();
+
+      if (data.error) throw new Error(data.error);
+
+      setConversations(data) // updating the zustand store
+      
+    } catch (error) {
+      toast.error(error.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [initialLimit]);
+
+  // Initial fetch 
+  useEffect(() => {
+    if (conversations.users?.length > 0) { // if the data is already loaded via the local storage only set the loading to false and return
+    setLoading(false);
+    return;
+  }
+  fetchConversations(initialLimit);
+  }, [fetchConversations, initialLimit, conversations.users]);
+
+  // loadMore function
+  const loadMore = () => {
+    if (conversations.hasNextPage) {
+      fetchConversations(initialLimit, conversations.nextCursor);
+    }
+  };
+
+  return { loading, conversations, loadMore };// exporting the loadMore function
 };
+
 export default useGetConversations;

--- a/frontend/src/hooks/useLogout.js
+++ b/frontend/src/hooks/useLogout.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useAuthContext } from "../context/AuthContext";
 import toast from "react-hot-toast";
+import useConversation from "../zustand/useConversation";
 
 const useLogout = () => {
 	const [loading, setLoading] = useState(false);
@@ -23,6 +24,9 @@ const useLogout = () => {
 			}
 
 			localStorage.removeItem("chat-user");
+			useConversation.persist.clearStorage(); // clearing the zustand local storage conversations on logout
+			const store = useConversation.getState(); 
+			store.setConversations({ users: [], nextCursor: null, hasNextPage: false });// clearing the zustand memory of the old conversations
 			setAuthUser(null);
 		} catch (error) {
 			toast.error(error.message);

--- a/frontend/src/utils/getConversation.js
+++ b/frontend/src/utils/getConversation.js
@@ -1,0 +1,19 @@
+// function resposible for fetchinng the conversation
+
+import toast from "react-hot-toast";
+
+export const getConversation = async (username,userId) => {
+  try {
+    const API = import.meta.env.VITE_API_URL || "";
+    const token = localStorage.getItem("chat-token");
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
+    const res = await fetch(`${API}/api/conversation?username=${username}&userId=${userId}`, {
+      credentials: "include",
+      headers,
+    });
+    const data = await res.json(); 
+    return data
+  } catch (error) {
+    toast.error(error.message);
+  }
+};

--- a/frontend/src/zustand/useConversation.js
+++ b/frontend/src/zustand/useConversation.js
@@ -1,10 +1,44 @@
 import { create } from "zustand";
-
-const useConversation = create((set) => ({
+import { persist, createJSONStorage } from 'zustand/middleware'
+const useConversation = create(
+	persist(
+	(set) => ({
 	selectedConversation: null,
 	setSelectedConversation: (selectedConversation) => set({ selectedConversation }),
 	messages: [],
 	setMessages: (messages) => set({ messages }),
-}));
+	conversations: {
+		users:[],
+		nextCursor:null,
+		hasNextPage:false,
+	},
+	setConversations: (conversations) => set({ conversations }), // this function updates the whole conversation array, used when loadMore button is clicked in sidebar
+	appendConversation: (conversation) => { // this function is used when a single user is to be appended in the sidebar i.e when using the searching option
+		 set((state) => {
+          // avoid duplicates based on _id
+          const alreadyExists = state.conversations.users.some(
+            (u) => u._id === conversation._id
+          );
+
+          if (alreadyExists) return state; // no change
+
+          return {
+            conversations: {
+              ...state.conversations,
+              users: [conversation, ...state.conversations.users],
+            },
+          };
+        });
+	}
+	}),
+	{ // persisting the conversation data in local storage
+      name: "conversation-storage",
+	  storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        conversations: state.conversations,
+        selectedConversation: state.selectedConversation,
+      }),
+    }
+));
 
 export default useConversation;


### PR DESCRIPTION
# Pull Request: Cursor-Based Fetching for Sidebar Users

## Motivation
The sidebar currently fetches all users at once, which can cause performance issues when the number of users grows. This PR implements cursor-based pagination to load users incrementally and improve UI responsiveness.

## Changes Made
- Updated `getUsersForSidebar` endpoint to support `limit` and `cursor` query parameters.  
- Modified filtering logic to fetch users in batches using `_id` as the cursor.  
- Updated frontend hook `useGetConversations` to support loading more users on demand.  
- Added `nextCursor` and `hasNextPage` in the response for frontend pagination.  
- Updated `Conversations` component to show a “Load More” button when more users are available.  
- Updated the Zustand store to hold the current batch of conversations and persist that data across page refreshes
- Created GET/conversation endpoint in the backend to search for a particular conversation 
- Created utility function to make use of the above mentioned endpoint and updated the searchInput component 

## Testing Notes
- Verified the sidebar loads the first batch of users on mount.  
- Clicking “Load More” fetches the next batch correctly.  
- State persists correctly across page refreshes (using Zustand + localStorage).  
- Search input searches the Conversations data collection from db rather than the conversations stored in frontend

here is a video demo

https://github.com/user-attachments/assets/42a41aba-97b2-4ef1-bdc4-dd13837b23fd


