### PR TITLE
persist data of zustand store

### DIFF
--- a/frontend/src/components/sidebar/Conversations.jsx
+++ b/frontend/src/components/sidebar/Conversations.jsx
@@ -1,14 +1,29 @@
+import { useState } from "react";
 import useGetConversations from "../../hooks/useGetConversations";
 import { getRandomEmoji } from "../../utils/emojis";
+import useConversation from "../../zustand/useConversation";
 import Conversation from "./Conversation";
+import { BsChevronUp, BsChevronDown } from "react-icons/bs";
 
 const Conversations = () => {
   const { loading, conversations,loadMore } = useGetConversations(); 
-	// conversations is now an object of the structure {
-	// 	users,
-	// 	nextCursor,
-	// 	hasNextPage
-	// }
+  const {setSlicedUsers} = useConversation()
+  const [offset,setOffset] = useState(0) // state variable to maintain the offset
+
+  // function to handle scrolling
+  const handleScroll = (direction,limit) => {
+    const total = conversations.users.length;
+    let newOffset = offset;
+
+    if (direction === "down") {
+      newOffset = Math.min(offset + limit, total - limit);
+    } else if (direction === "up") {
+      newOffset = Math.max(offset - limit, 0);
+    }
+
+    setOffset(newOffset);
+    setSlicedUsers(conversations.users.slice(newOffset, newOffset + limit));
+};
 
   return (
     <div className="py-2 flex flex-col overflow-auto">
@@ -17,15 +32,27 @@ const Conversations = () => {
         <span className="loading loading-spinner mx-auto"></span>
       ) : (
         <>
-          {conversations.users.map((conversation, idx) => (
+        <button 
+        className="m-auto"
+        onClick={()=> handleScroll("up",5)}>
+          <BsChevronUp size={18} />
+        </button>
+        <div className="overflow-auto my-2">
+        {conversations.slicedUsers.map((conversation, idx) => (
             <Conversation
               key={conversation._id}
               conversation={conversation}
               emoji={getRandomEmoji()}
-              lastIdx={idx === conversations.users.length - 1}
+              lastIdx={idx === conversations.slicedUsers.length - 1}
             />
-          ))}
-		  {conversations.hasNextPage?<button onClick={loadMore}>Load more</button>:null}
+         ))}
+         </div>
+        <button 
+        className="m-auto"
+        onClick={()=> handleScroll("down",5)}>
+          <BsChevronDown size={18} />
+        </button>
+		    {conversations.hasNextPage?<button onClick={loadMore}>Load more</button>:null}
         </>
       )}
     </div>

--- a/frontend/src/hooks/useGetConversations.js
+++ b/frontend/src/hooks/useGetConversations.js
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import toast from "react-hot-toast";
 import useConversation from "../zustand/useConversation";
 
-const useGetConversations = (initialLimit = 1) => { // initial limit set this low for testing purpose only
+const useGetConversations = (initialLimit = 5) => { 
   const [loading, setLoading] = useState(true);
   const { conversations, setConversations } = useConversation();// using zustand store to get conversations
 

--- a/frontend/src/hooks/useLogout.js
+++ b/frontend/src/hooks/useLogout.js
@@ -26,7 +26,7 @@ const useLogout = () => {
 			localStorage.removeItem("chat-user");
 			useConversation.persist.clearStorage(); // clearing the zustand local storage conversations on logout
 			const store = useConversation.getState(); 
-			store.setConversations({ users: [], nextCursor: null, hasNextPage: false });// clearing the zustand memory of the old conversations
+			store.setConversations({ users: [], nextCursor: null, hasNextPage: false },true);// clearing the zustand memory of the old conversations
 			setAuthUser(null);
 		} catch (error) {
 			toast.error(error.message);

--- a/frontend/src/zustand/useConversation.js
+++ b/frontend/src/zustand/useConversation.js
@@ -11,12 +11,44 @@ const useConversation = create(
 		users:[],
 		nextCursor:null,
 		hasNextPage:false,
+    slicedUsers:[] // sliced users contain the current batch of users to show in the sidebar
 	},
-	setConversations: (conversations) => set({ conversations }), // this function updates the whole conversation array, used when loadMore button is clicked in sidebar
-	appendConversation: (conversation) => { // this function is used when a single user is to be appended in the sidebar i.e when using the searching option
+	setConversations: (newData,clear=false) => // set conversation now persist the previous users
+        set((state) => {
+          if(clear){ // clear is a flag variable which decides if the data is to be reset (in case of logout)
+            return {
+              conversations: {
+		                          users:[],
+		                          nextCursor:null,
+		                          hasNextPage:false,
+                              slicedUsers:[]
+	            }
+            }
+          }
+          const existingUsers = state.conversations.users;
+          const newUsers = newData.users || [];
+
+          // Filter out duplicates by _id
+          const mergedUsers = [
+            ...existingUsers,
+            ...newUsers.filter(
+              (newUser) => !existingUsers.some((u) => u._id === newUser._id)
+            ),
+          ];
+    
+          return {
+            conversations: {
+              users: mergedUsers,
+              nextCursor: newData.nextCursor ?? state.conversations.nextCursor,
+              hasNextPage: newData.hasNextPage ?? state.conversations.hasNextPage,
+              slicedUsers: newUsers
+            },
+          };
+        }),
+	appendConversation: (conversation) =>  // this function is used when a single user is to be appended in the sidebar i.e when using the searching option
 		 set((state) => {
           // avoid duplicates based on _id
-          const alreadyExists = state.conversations.users.some(
+          const alreadyExists = state.conversations.slicedUsers.some( // append to slicedUsers now
             (u) => u._id === conversation._id
           );
 
@@ -25,11 +57,18 @@ const useConversation = create(
           return {
             conversations: {
               ...state.conversations,
-              users: [conversation, ...state.conversations.users],
+              slicedUsers: [conversation, ...state.conversations.slicedUsers],
             },
           };
-        });
-	}
+        }),
+
+  setSlicedUsers: (data) => // function to set the sliced users
+    set((state)=>({
+      conversations: {
+        ...state.conversations,
+        slicedUsers: data
+      }
+    }))
 	}),
 	{ // persisting the conversation data in local storage
       name: "conversation-storage",
@@ -37,6 +76,7 @@ const useConversation = create(
       partialize: (state) => ({
         conversations: state.conversations,
         selectedConversation: state.selectedConversation,
+        slicedUsers: state.slicedUsers
       }),
     }
 ));


### PR DESCRIPTION
# Persist Previously Fetched Users in Zustand Store

## Description
Currently, the `conversations.users` array in the Zustand store is **replaced entirely** whenever a new batch of users is fetched from the API. This causes previously loaded users to be lost when paginating.

## Changes Made
- Updated the `setConversations` function in the Zustand store to **append new users** to the existing array instead of overwriting it.  
- When fetching a new batch of users, the store now **merges the incoming users** with the existing ones.  
- Added a slicedUsers array in the conversations object in zustand to hold the current batch of users
- Added a new SetSlicedUsers function in to maintain the slicedUsers array
- Frontend now allows users to **navigate up and down between paginated users** without losing the previously loaded data.

## Motivation
This change improves the user experience by enabling **smooth pagination**. Previously fetched users remain visible while fetching new ones, reducing unnecessary API calls and visual disruption.

## Testing
- Verified that when loading additional users, the previous users remain in the list.  
- Confirmed navigation through pagination maintains all loaded users.  
- Checked that duplicates are not added when re-fetching existing users.

## Video Demo

https://github.com/user-attachments/assets/4c8fc2c5-d45d-438f-b0f8-3d2c4ae7d38b


