### PR TITLE
feat(read-receipts):  sent/delivered/seen indicators with real time updates.

### DIFF
--- a/backend/controllers/message.controller.js
+++ b/backend/controllers/message.controller.js
@@ -41,6 +41,8 @@ export const sendMessage = async (req, res) => {
 			message,
 			fileUrl,
 			fileType,
+			deliveredTo: [receiverId], // Mark as delivered to receiver
+			seenBy: [],
 		});
 
 		if (newMessage) {
@@ -78,15 +80,41 @@ export const getMessages = async (req, res) => {
 			return res.status(403).json({ error: "You cannot view messages with this user" });
 		}
 
-		const conversation = await Conversation.findOne({
-			participants: { $all: [senderId, userToChatId] },
-		}).populate("messages"); // NOT REFERENCE BUT ACTUAL MESSAGES
+				const conversation = await Conversation.findOne({
+						participants: { $all: [senderId, userToChatId] },
+				}).populate("messages");
 
-		if (!conversation) return res.status(200).json([]);
+				if (!conversation) return res.status(200).json([]);
 
-		const messages = conversation.messages;
+				// Determine which messages should be marked as seen
+				const toMarkSeen = conversation.messages.filter(
+					(m) => String(m.receiverId) === String(senderId) && !(m.seenBy || []).some((u) => String(u) === String(senderId))
+				);
+				const toMarkIds = toMarkSeen.map((m) => m._id);
 
-		res.status(200).json(messages);
+				if (toMarkIds.length) {
+					await Message.updateMany(
+						{ _id: { $in: toMarkIds } },
+						{ $addToSet: { seenBy: senderId } }
+					);
+
+					// Notify original sender that these messages were seen
+					const otherUserSocketId = getReceiverSocketId(userToChatId);
+					if (otherUserSocketId) {
+						io.to(otherUserSocketId).emit("messagesSeen", {
+							by: senderId,
+							messageIds: toMarkIds,
+						});
+					}
+				}
+
+				// Refetch messages to get updated seenBy
+				const updatedConversation = await Conversation.findOne({
+						participants: { $all: [senderId, userToChatId] },
+				}).populate("messages");
+				const messages = updatedConversation.messages;
+
+				res.status(200).json(messages);
 	} catch (error) {
 		console.log("Error in getMessages controller: ", error.message);
 		res.status(500).json({ error: "Internal server error" });

--- a/backend/models/message.model.js
+++ b/backend/models/message.model.js
@@ -21,6 +21,14 @@ const messageSchema = new mongoose.Schema(
         fileType: {
             type: String,
         },
+        deliveredTo: [{
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User"
+        }],
+        seenBy: [{
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User"
+        }],
         // createdAt, updatedAt
     },
     { timestamps: true }

--- a/frontend/src/components/messages/Message.jsx
+++ b/frontend/src/components/messages/Message.jsx
@@ -3,6 +3,7 @@ import { useAuthContext } from "../../context/AuthContext";
 import { extractTime } from "../../utils/extractTime";
 import useConversation from "../../zustand/useConversation";
 import { FaFileAlt } from "react-icons/fa";
+import { FaCheck, FaCheckDouble } from "react-icons/fa";
 import ReactMarkdown from "react-markdown";
 // 1. IMPORT THE NEW PLUGIN
 import remarkGfm from "remark-gfm";
@@ -72,9 +73,21 @@ const Message = ({ message }) => {
                 )}
             </div>
 
-            <div className="chat-footer opacity-50 text-xs flex gap-1 items-center text-gray-800 dark:text-gray-300">
-                {formattedTime}
-            </div>
+                        <div className="chat-footer opacity-50 text-xs flex gap-1 items-center text-gray-800 dark:text-gray-300">
+                                {formattedTime}
+                                {fromMe && (
+                                    <span className="ml-1 flex items-center">
+                                        {/* WhatsApp-like ticks */}
+                                        {message.seenBy && message.seenBy.length > 0 ? (
+                                            <FaCheckDouble style={{ color: "#25D366" }} title="Seen" />
+                                        ) : message.deliveredTo && message.deliveredTo.length > 0 ? (
+                                            <FaCheckDouble style={{ color: "#aaa" }} title="Delivered" />
+                                        ) : (
+                                            <FaCheck style={{ color: "#aaa" }} title="Sent" />
+                                        )}
+                                    </span>
+                                )}
+                        </div>
         </div>
     );
 };

--- a/frontend/src/hooks/useListenMessages.js
+++ b/frontend/src/hooks/useListenMessages.js
@@ -17,7 +17,22 @@ const useListenMessages = () => {
 			setMessages([...messages, newMessage]);
 		});
 
-		return () => socket?.off("newMessage");
+		// Update messages as seen on sender's side
+		socket?.on("messagesSeen", ({ by, messageIds }) => {
+			if (!Array.isArray(messageIds) || !messageIds.length) return;
+			setMessages(
+				messages.map((m) =>
+					messageIds.some((id) => String(id) === String(m._id))
+						? { ...m, seenBy: Array.isArray(m.seenBy) ? [...new Set([...m.seenBy, by])] : [by] }
+						: m
+				)
+			);
+		});
+
+		return () => {
+			socket?.off("newMessage");
+			socket?.off("messagesSeen");
+		};
 	}, [socket, setMessages, messages]);
 };
 export default useListenMessages;


### PR DESCRIPTION
# feat(read-receipts): Sent/delivered/seen indicators with realtime updates

## Summary
This PR adds read receipts to ChittChat:
- Single gray tick = Sent
- Double gray tick = Delivered
- Double green tick = Seen

It works in real time via Socket.io and persists status in the database for reliability.

## What’s included
- Backend
  - Message model now tracks delivery and read status:
    - `deliveredTo: ObjectId[]` — users/devices that have received the message
    - `seenBy: ObjectId[]` — users who have opened/read the message
  - `sendMessage` controller
    - Initializes `deliveredTo` with the receiver immediately after DB save
  - `getMessages` controller
    - Marks any messages addressed to the current viewer as seen
    - Emits a `messagesSeen` socket event to the other participant with the updated message IDs
- Frontend
  - `Message.jsx` renders ticks for messages sent by the current user:
    - Single gray tick (sent) → default if no delivery/read info
    - Double gray tick (delivered) → `deliveredTo.length > 0`
    - Double green tick (seen) → `seenBy.length > 0`
  - `useListenMessages` listens for:
    - `newMessage` to append incoming messages
    - `messagesSeen` to update existing messages to “seen” in real time

## Technical Details

### Data model
- File: `backend/models/message.model.js`
- New fields:
  - `deliveredTo: [{ type: ObjectId, ref: 'User' }]`
  - `seenBy: [{ type: ObjectId, ref: 'User' }]`
- Backward-compatible: existing documents without these fields still render single tick.

### Controllers
- File: `backend/controllers/message.controller.js`
- Send flow:
  - Creates `Message` with `deliveredTo: [receiverId]`, `seenBy: []`.
- Seen flow:
  - On `GET /api/messages/:id`, marks messages addressed to the viewer as seen:
    - `$addToSet: { seenBy: viewerId }`
  - Emits:
    ```json
    {
      "event": "messagesSeen",
      "payload": { "by": "<viewerId>", "messageIds": ["<msgId1>", "<msgId2>", ...] }
    }
    ```

### Sockets
- Emits: `newMessage`, `messagesSeen`
- Client updates `seenBy` on matching messages without refresh.

### UI Rendering
- File: `frontend/src/components/messages/Message.jsx`
- Logic (sender’s perspective):
  - Sent: no `deliveredTo` or `seenBy` → single gray tick
  - Delivered: `deliveredTo.length > 0` → double gray tick
  - Seen: `seenBy.length > 0` → double green tick

## How to Validate
- Open two sessions (e.g., normal + incognito), log in as two different users.
- From User A → send a message to User B:
  - A’s message shows double gray tick immediately (delivered).
- Open the conversation on User B (or refresh that thread):
  - The message flips to double green tick on A’s side in real time (seen).


## Files Touched
- Backend
  - `backend/models/message.model.js`
  - `backend/controllers/message.controller.js`
- Frontend
  - `frontend/src/components/messages/Message.jsx`
  - `frontend/src/hooks/useListenMessages.js`

## Branch
- `read-receipts`

---

This PR delivers a consistent, real-time read receipts experience  while keeping the implementation simple, robust, and backward-compatible.